### PR TITLE
.github/workflows: avoid multiple builds and save cost

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: v1.19
-    - run: go build ./...
     - run: make test
 
   lint:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -26,10 +26,6 @@ jobs:
     - name: Set LDFLAGS
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
-    - name: Build
-      run: |
-        go build ./cmd/konnector
-
     # Build ko from HEAD, build and push an image tagged with the commit SHA,
     # then keylessly sign it with cosign.
     - name: Publish and sign image


### PR DESCRIPTION
In Makefile we build with ldflags. These extra builds are harmful for both cost and time.