### PR TITLE
example-backend: only show CRDs of the right scope

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS
-      run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
+      run: echo LDFLAGS="$(make ldflags)" | tee -a >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -24,7 +24,7 @@ jobs:
       run: go install github.com/google/ko@latest
 
     - name: Set LDFLAGS
-      run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
+      run: echo LDFLAGS="$(make ldflags)" | tee -a >> $GITHUB_ENV
 
     # Build ko from HEAD, build and push an image tagged with the commit SHA,
     # then keylessly sign it with cosign.

--- a/contrib/example-backend/server.go
+++ b/contrib/example-backend/server.go
@@ -94,6 +94,7 @@ func NewServer(config *Config) (*Server, error) {
 		callback,
 		config.Options.PrettyName,
 		config.Options.TestingAutoSelect,
+		kubebindv1alpha1.Scope(config.Options.ConsumerScope),
 		s.Kubernetes,
 		config.ApiextensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Lister(),
 	)

--- a/pkg/konnector/controllers/cluster/serviceexport/serviceexport_reconcile.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/serviceexport_reconcile.go
@@ -47,7 +47,7 @@ func (r *reconciler) reconcile(ctx context.Context, export *kubebindv1alpha1.API
 			kubebindv1alpha1.APIServiceExportConditionConnected,
 			"NoServiceBinding",
 			conditionsapi.ConditionSeverityInfo,
-			"No ServiceBindings found for APIServiceExport",
+			"No APIServiceBindings found for APIServiceExport",
 		)
 	} else if len(bindings) > 1 {
 		conditions.MarkFalse(
@@ -55,7 +55,7 @@ func (r *reconciler) reconcile(ctx context.Context, export *kubebindv1alpha1.API
 			kubebindv1alpha1.APIServiceExportConditionConnected,
 			"MultipleServiceBindings",
 			conditionsapi.ConditionSeverityError,
-			"Multiple ServiceBindings found for APIServiceExport. Delete all but one.",
+			"Multiple APIServiceBindings found for APIServiceExport. Delete all but one.",
 		)
 	} else {
 		conditions.MarkTrue(


### PR DESCRIPTION
In namespaced scope of the backend, only show namespaced CRDs on the resources page.