### PR TITLE
.ko.yaml: set ldflags for the right packages

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,6 +2,11 @@ baseImageOverrides:
   github.com/google/ko: golang:1.19
 
 builds:
-- id: ko
+- id: konnector
+  dir: ./cmd/konnector
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+- id: example-backend
+  dir: ./cmd/example-backend
   ldflags:
   - "{{ .Env.LDFLAGS }}"


### PR DESCRIPTION
To get the right version string in the konnector image, hopefully.