### PR TITLE
Refactor the backend HTTP Server

### DIFF
--- a/contrib/example-backend/http/handler.go
+++ b/contrib/example-backend/http/handler.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/gorilla/securecookie"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -99,12 +98,12 @@ func NewHandler(
 	}, nil
 }
 
-func (h *handler) AddRoutes(mux *mux.Router) {
-	mux.HandleFunc("/export", h.handleServiceExport).Methods("GET")
-	mux.HandleFunc("/resources", h.handleResources).Methods("GET")
-	mux.HandleFunc("/bind", h.handleBind).Methods("GET")
-	mux.HandleFunc("/authorize", h.handleAuthorize).Methods("GET")
-	mux.HandleFunc("/callback", h.handleCallback).Methods("GET")
+func (h *handler) AddRoutes(server *Server) {
+	server.AddRoute("/export", h.handleServiceExport, http.MethodGet)
+	server.AddRoute("/resources", h.handleResources, http.MethodGet)
+	server.AddRoute("/bind", h.handleBind, http.MethodGet)
+	server.AddRoute("/authorize", h.handleAuthorize, http.MethodGet)
+	server.AddRoute("/callback", h.handleCallback, http.MethodGet)
 }
 
 func (h *handler) handleServiceExport(w http.ResponseWriter, r *http.Request) {

--- a/contrib/example-backend/http/server.go
+++ b/contrib/example-backend/http/server.go
@@ -63,7 +63,7 @@ func (s *Server) Addr() net.Addr {
 func (s *Server) Start(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
-		s.server.Close() // nolint:errcheck
+		s.Close() // nolint:errcheck
 	}()
 
 	go func() {
@@ -77,6 +77,10 @@ func (s *Server) Start(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) Shutdown() error {
+func (s *Server) Close() error {
 	return s.server.Close()
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }

--- a/contrib/example-backend/server.go
+++ b/contrib/example-backend/server.go
@@ -121,7 +121,7 @@ func NewServer(config *Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error setting up HTTP Handler: %w", err)
 	}
-	handler.AddRoutes(s.WebServer.Router)
+	handler.AddRoutes(s.WebServer)
 
 	// construct controllers
 	s.ClusterBinding, err = clusterbinding.NewController(


### PR DESCRIPTION
This is a bit of plumbing for the http server, in order to use it instead of using different libs(`"github.com/labstack/echo/v4"` ) for achieving similar functionalities.   