### PR TITLE
contrib/example-backend: remove listen-ip/listen-port in favor of listen-address

### DIFF
--- a/contrib/example-backend/http/server.go
+++ b/contrib/example-backend/http/server.go
@@ -41,7 +41,11 @@ func NewServer(options *options.Serve) (*Server, error) {
 
 	if options.Listener == nil {
 		var err error
-		server.listener, err = net.Listen("tcp", net.JoinHostPort(options.ListenIP, strconv.Itoa(options.ListenPort)))
+		addr := options.ListenAddress
+		if options.ListenIP != "" {
+			addr = net.JoinHostPort(options.ListenIP, strconv.Itoa(options.ListenPort))
+		}
+		server.listener, err = net.Listen("tcp", addr)
 		if err != nil {
 			return nil, err
 		}

--- a/contrib/manifests/example-backend/insecure/example-backend.yaml
+++ b/contrib/manifests/example-backend/insecure/example-backend.yaml
@@ -31,8 +31,7 @@ spec:
             - --oidc-issuer-client-secret=$(OIDC-ISSUER-CLIENT-SECRET)
             - --oidc-issuer-url=$(OIDC-ISSUER-URL)
             - --oidc-callback-url=$(OIDC-CALLBACK-URL)
-            - --listen-ip=0.0.0.0
-            - --listen-port=443
+            - --listen-address=0.0.0.0:443
             - --cookie-signing-key=$(COOKIE-SIGNING-KEY)
           env:
             - name: OIDC-ISSUER-CLIENT-ID

--- a/contrib/manifests/example-backend/letsencrypt/example-backend.yaml
+++ b/contrib/manifests/example-backend/letsencrypt/example-backend.yaml
@@ -31,8 +31,7 @@ spec:
             - --oidc-issuer-url=$(OIDC-ISSUER-URL)
             - --oidc-authorize-url=$(OIDC-AUTHORIZE-URL)
             - --oidc-callback-url=$(OIDC-CALLBACK-URL)
-            - --listen-ip=0.0.0.0
-            - --listen-port=8080
+            - --listen-address=0.0.0.0:8080
             - --external-address=https://api.mangodb.de
             - --external-ca-file=/etc/tls/ca.crt
             - --external-server-name=78615b03-d644-4fb7-8395-8a60efd388f2.k8s.ondigitalocean.com


### PR DESCRIPTION
This introduces `--listen-address` which is more idiomatic and can include a port as well.
This is a preparation for new command line options for the cache implementation.

cc @sttts 