### PR TITLE
Seed rng for random oauth sessionid

### DIFF
--- a/cmd/kubectl-bind/main.go
+++ b/cmd/kubectl-bind/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -27,6 +29,10 @@ import (
 	apiservicecmd "github.com/kube-bind/kube-bind/pkg/kubectl/bind-apiservice/cmd"
 	bindcmd "github.com/kube-bind/kube-bind/pkg/kubectl/bind/cmd"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixMilli())
+}
 
 func main() {
 	flags := pflag.NewFlagSet("kubectl-bind", pflag.ExitOnError)

--- a/pkg/kubectl/bind/plugin/bind.go
+++ b/pkg/kubectl/bind/plugin/bind.go
@@ -227,6 +227,7 @@ func (b *BindOptions) Run(ctx context.Context, urlCh chan<- string) error {
 	}
 
 	// create kube-bind namespace
+	// TODO(rikatz): Is this duplicated with line 178?
 	if _, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "kube-bind",
@@ -234,7 +235,7 @@ func (b *BindOptions) Run(ctx context.Context, urlCh chan<- string) error {
 	}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	} else if err == nil {
-		fmt.Fprintf(b.Options.IOStreams.ErrOut, "📦 Created kube-binding namespace.\n") // nolint: errcheck
+		fmt.Fprintf(b.Options.IOStreams.ErrOut, "📦 Created kube-bind namespace.\n") // nolint: errcheck
 	}
 
 	// copy kubeconfig into local cluster


### PR DESCRIPTION
The random number generator is not being properly initialized. This makes the sessionID on oauth workflow not be properly randomized, and make it easier to intercept/impersonate it.