### PR TITLE
Use BindOptions-wide resource printer

### DIFF
--- a/pkg/kubectl/bind/plugin/bind.go
+++ b/pkg/kubectl/bind/plugin/bind.go
@@ -55,9 +55,9 @@ type BindOptions struct {
 	*base.Options
 	Logs *logs.Options
 
-	PrintFlags *genericclioptions.PrintFlags
-	Printer    printers.ResourcePrinter
-	DryRun     bool
+	Print   *genericclioptions.PrintFlags
+	Printer printers.ResourcePrinter
+	DryRun  bool
 
 	// url is the argument accepted by the command. It contains the
 	// reference to where an APIService exists.
@@ -75,9 +75,9 @@ type BindOptions struct {
 // NewBindOptions returns new BindOptions.
 func NewBindOptions(streams genericclioptions.IOStreams) *BindOptions {
 	opts := &BindOptions{
-		Options:    base.NewOptions(streams),
-		Logs:       logs.NewOptions(),
-		PrintFlags: genericclioptions.NewPrintFlags("kubectl-bind").WithDefaultOutput("yaml"),
+		Options: base.NewOptions(streams),
+		Logs:    logs.NewOptions(),
+		Print:   genericclioptions.NewPrintFlags("kubectl-bind").WithDefaultOutput("yaml"),
 
 		Runner: func(cmd *exec.Cmd) error {
 			return cmd.Run()
@@ -93,7 +93,7 @@ func (b *BindOptions) AddCmdFlags(cmd *cobra.Command) {
 
 	b.Options.BindFlags(cmd)
 	logsv1.AddFlags(b.Logs, cmd.Flags())
-	b.PrintFlags.AddFlags(cmd)
+	b.Print.AddFlags(cmd)
 
 	cmd.Flags().BoolVar(&b.SkipKonnector, "skip-konnector", b.SkipKonnector, "Skip the deployment of the konnector")
 	cmd.Flags().BoolVarP(&b.DryRun, "dry-run", "d", b.DryRun, "If true, only print the requests that would be sent to the service provider after authentication, without actually binding.")
@@ -109,11 +109,7 @@ func (b *BindOptions) Complete(args []string) error {
 		b.URL = args[0]
 	}
 
-	if b.DryRun {
-		b.PrintFlags.Complete("%s (dry run)") // nolint: errcheck
-	}
-
-	printer, err := b.PrintFlags.ToPrinter()
+	printer, err := b.Print.ToPrinter()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/bind/plugin/bind.go
+++ b/pkg/kubectl/bind/plugin/bind.go
@@ -110,7 +110,7 @@ func (b *BindOptions) Complete(args []string) error {
 	}
 
 	if b.DryRun {
-		b.PrintFlags.Complete("%s (dry run)")
+		b.PrintFlags.Complete("%s (dry run)") // nolint: errcheck
 	}
 
 	printer, err := b.PrintFlags.ToPrinter()

--- a/pkg/kubectl/bind/plugin/bind.go
+++ b/pkg/kubectl/bind/plugin/bind.go
@@ -56,7 +56,7 @@ type BindOptions struct {
 	Logs *logs.Options
 
 	Print   *genericclioptions.PrintFlags
-	Printer printers.ResourcePrinter
+	printer printers.ResourcePrinter
 	DryRun  bool
 
 	// url is the argument accepted by the command. It contains the
@@ -114,7 +114,7 @@ func (b *BindOptions) Complete(args []string) error {
 		return err
 	}
 
-	b.Printer = printer
+	b.printer = printer
 
 	return nil
 }
@@ -262,7 +262,7 @@ func (b *BindOptions) Run(ctx context.Context, urlCh chan<- string) error {
 	// print the request in dry-run mode
 	if b.DryRun {
 		for _, request := range apiRequests {
-			if err = b.Printer.PrintObj(request, b.IOStreams.Out); err != nil {
+			if err = b.printer.PrintObj(request, b.IOStreams.Out); err != nil {
 				return err
 			}
 		}

--- a/test/e2e/framework/bind.go
+++ b/test/e2e/framework/bind.go
@@ -34,7 +34,7 @@ import (
 	bindplugin "github.com/kube-bind/kube-bind/pkg/kubectl/bind/plugin"
 )
 
-func Bind(t *testing.T, authURLCh chan<- string, invocations chan<- SubCommandInvocation, positionalArg string, flags ...string) {
+func Bind(t *testing.T, iostreams genericclioptions.IOStreams, authURLCh chan<- string, invocations chan<- SubCommandInvocation, positionalArg string, flags ...string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -44,7 +44,7 @@ func Bind(t *testing.T, authURLCh chan<- string, invocations chan<- SubCommandIn
 	}
 	t.Logf("kubectl bind %s", strings.Join(args, " "))
 
-	opts := bindplugin.NewBindOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	opts := bindplugin.NewBindOptions(iostreams)
 	cmd := &cobra.Command{}
 	opts.AddCmdFlags(cmd)
 	err := cmd.Flags().Parse(flags)
@@ -54,6 +54,7 @@ func Bind(t *testing.T, authURLCh chan<- string, invocations chan<- SubCommandIn
 	require.NoError(t, err)
 	err = opts.Validate()
 	require.NoError(t, err)
+
 	opts.Runner = func(cmd *exec.Cmd) error {
 		bs, err := io.ReadAll(cmd.Stdin)
 		if err != nil {


### PR DESCRIPTION
ResourcePrinter supports adding yaml separator automatically. Only requirement is using the same ResourcePrinter object for all resources.

This PR removes the hacky solution and makes changes to better align with standard kubectl commands.