### PR TITLE
fix a panic in the example backend

### DIFF
--- a/contrib/example-backend/kubernetes/manager.go
+++ b/contrib/example-backend/kubernetes/manager.go
@@ -121,10 +121,10 @@ func (m *Manager) HandleResources(ctx context.Context, identity, resource, group
 		ns = nss[0].(*corev1.Namespace).Name
 	} else {
 		nsObj, err := kuberesources.CreateNamespace(ctx, m.kubeClient, m.namespacePrefix, identity)
-		logger.Info("Created namespace", "namespace", nsObj.Name)
 		if err != nil {
 			return nil, err
 		}
+		logger.Info("Created namespace", "namespace", nsObj.Name)
 		ns = nsObj.Name
 	}
 	logger = logger.WithValues("namespace", ns)


### PR DESCRIPTION
Here's the panic I got:

```
2022/12/02 13:18:44 http: panic serving 127.0.0.1:53118: runtime error: invalid memory address or nil pointer dereference
goroutine 2404 [running]:
net/http.(*conn).serve.func1()
	/home/linuxbrew/.linuxbrew/Cellar/go/1.19.3/libexec/src/net/http/server.go:1850 +0xbf
panic({0x1c4fb80, 0x32f16f0})
	/home/linuxbrew/.linuxbrew/Cellar/go/1.19.3/libexec/src/runtime/panic.go:890 +0x262
github.com/kube-bind/kube-bind/contrib/example-backend/kubernetes.(*Manager).HandleResources(0xc0002e7380, {0x2254240, 0xc00093ff50}, {0xc00064b3e0, 0x23}, {0xc000a88cdc, 0x8}, {0xc000a88ceb, 0xb})
	/home/nick/src/kube-bind/contrib/example-backend/kubernetes/manager.go:124 +0x3ee
github.com/kube-bind/kube-bind/contrib/example-backend/http.(*handler).handleBind(0xc000181760, {0x2252f08, 0xc0004d8620}, 0xc0007eb000)
	/home/nick/src/kube-bind/contrib/example-backend/http/handler.go:369 +0x56a
net/http.HandlerFunc.ServeHTTP(0xc0007eaf00?, {0x2252f08?, 0xc0004d8620?}, 0x800?)
```

seemed easy enough to fix, so here's a quick patch to fix it!