### PR TITLE
Fix servicebinding controller reconciler bug

### DIFF
--- a/pkg/konnector/controllers/cluster/cluster_controller.go
+++ b/pkg/konnector/controllers/cluster/cluster_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubernetesinformers "k8s.io/client-go/informers"
-	coreinformers "k8s.io/client-go/informers/core/v1"
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
@@ -58,11 +57,11 @@ const (
 func NewController(
 	consumerSecretRefKey string,
 	providerNamespace string,
+	serviceBindingName string,
 	consumerConfig, providerConfig *rest.Config,
 	namespaceInformer dynamic.Informer[corelisters.NamespaceLister],
 	serviceBindingInformer dynamic.Informer[bindlisters.APIServiceBindingLister],
 	crdInformer dynamic.Informer[crdlisters.CustomResourceDefinitionLister],
-	secretInformer coreinformers.SecretInformer,
 ) (*controller, error) {
 	consumerConfig = rest.CopyConfig(consumerConfig)
 	consumerConfig = rest.AddUserAgent(consumerConfig, controllerName)
@@ -127,12 +126,12 @@ func NewController(
 	servicebindingCtrl, err := servicebinding.NewController(
 		consumerSecretRefKey,
 		providerNamespace,
+		serviceBindingName,
 		consumerConfig,
 		providerConfig,
 		serviceBindingInformer,
 		providerBindInformers.KubeBind().V1alpha1().APIServiceExports(),
 		crdInformer,
-		secretInformer,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/konnector/controllers/cluster/cluster_controller.go
+++ b/pkg/konnector/controllers/cluster/cluster_controller.go
@@ -57,7 +57,7 @@ const (
 func NewController(
 	consumerSecretRefKey string,
 	providerNamespace string,
-	serviceBindingName string,
+	reconcileServiceBinding func(binding *kubebindv1alpha1.APIServiceBinding) bool,
 	consumerConfig, providerConfig *rest.Config,
 	namespaceInformer dynamic.Informer[corelisters.NamespaceLister],
 	serviceBindingInformer dynamic.Informer[bindlisters.APIServiceBindingLister],
@@ -126,7 +126,7 @@ func NewController(
 	servicebindingCtrl, err := servicebinding.NewController(
 		consumerSecretRefKey,
 		providerNamespace,
-		serviceBindingName,
+		reconcileServiceBinding,
 		consumerConfig,
 		providerConfig,
 		serviceBindingInformer,

--- a/pkg/konnector/controllers/cluster/cluster_controller.go
+++ b/pkg/konnector/controllers/cluster/cluster_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubernetesinformers "k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
@@ -61,6 +62,7 @@ func NewController(
 	namespaceInformer dynamic.Informer[corelisters.NamespaceLister],
 	serviceBindingInformer dynamic.Informer[bindlisters.APIServiceBindingLister],
 	crdInformer dynamic.Informer[crdlisters.CustomResourceDefinitionLister],
+	secretInformer coreinformers.SecretInformer,
 ) (*controller, error) {
 	consumerConfig = rest.CopyConfig(consumerConfig)
 	consumerConfig = rest.AddUserAgent(consumerConfig, controllerName)
@@ -130,6 +132,7 @@ func NewController(
 		serviceBindingInformer,
 		providerBindInformers.KubeBind().V1alpha1().APIServiceExports(),
 		crdInformer,
+		secretInformer,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_controller.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
@@ -29,6 +30,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -54,6 +56,7 @@ func NewController(
 	serviceBindingInformer dynamic.Informer[bindlisters.APIServiceBindingLister],
 	serviceExportInformer bindinformers.APIServiceExportInformer,
 	crdInformer dynamic.Informer[apiextensionslisters.CustomResourceDefinitionLister],
+	secretInformer coreinformers.SecretInformer,
 ) (*controller, error) {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName)
 
@@ -100,6 +103,9 @@ func NewController(
 			},
 			getClusterBinding: func(ctx context.Context) (*kubebindv1alpha1.ClusterBinding, error) {
 				return providerBindClient.KubeBindV1alpha1().ClusterBindings(providerNamespace).Get(ctx, "cluster", metav1.GetOptions{})
+			},
+			getSecret: func(ns, name string) (*corev1.Secret, error) {
+				return secretInformer.Lister().Secrets(ns).Get(name)
 			},
 			updateServiceExportStatus: func(ctx context.Context, export *kubebindv1alpha1.APIServiceExport) (*kubebindv1alpha1.APIServiceExport, error) {
 				return providerBindClient.KubeBindV1alpha1().APIServiceExports(providerNamespace).UpdateStatus(ctx, export, metav1.UpdateOptions{})

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_controller.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_controller.go
@@ -49,7 +49,8 @@ const (
 
 // NewController returns a new controller for ServiceBindings.
 func NewController(
-	consumerSecretRefKey, providerNamespace, serviceBindingName string,
+	consumerSecretRefKey, providerNamespace string,
+	reconcileServiceBinding func(binding *kubebindv1alpha1.APIServiceBinding) bool,
 	consumerConfig, providerConfig *rest.Config,
 	serviceBindingInformer dynamic.Informer[bindlisters.APIServiceBindingLister],
 	serviceExportInformer bindinformers.APIServiceExportInformer,
@@ -89,9 +90,9 @@ func NewController(
 		crdInformer: crdInformer,
 
 		reconciler: reconciler{
-			consumerSecretRefKey: consumerSecretRefKey,
-			providerNamespace:    providerNamespace,
-			serviceBindingName:   serviceBindingName,
+			consumerSecretRefKey:    consumerSecretRefKey,
+			providerNamespace:       providerNamespace,
+			reconcileServiceBinding: reconcileServiceBinding,
 
 			getServiceExport: func(name string) (*kubebindv1alpha1.APIServiceExport, error) {
 				return serviceExportInformer.Lister().APIServiceExports(providerNamespace).Get(name)

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
@@ -19,13 +19,10 @@ package servicebinding
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
 	kubebindv1alpha1 "github.com/kube-bind/kube-bind/pkg/apis/kubebind/v1alpha1"
@@ -35,12 +32,11 @@ import (
 )
 
 type reconciler struct {
-	consumerSecretRefKey, providerNamespace string
+	consumerSecretRefKey, providerNamespace, serviceBindingName string
 
 	getServiceExport  func(ns string) (*kubebindv1alpha1.APIServiceExport, error)
 	getServiceBinding func(name string) (*kubebindv1alpha1.APIServiceBinding, error)
 	getClusterBinding func(ctx context.Context) (*kubebindv1alpha1.ClusterBinding, error)
-	getSecret         func(ns, name string) (*corev1.Secret, error)
 
 	updateServiceExportStatus func(ctx context.Context, export *kubebindv1alpha1.APIServiceExport) (*kubebindv1alpha1.APIServiceExport, error)
 
@@ -50,36 +46,11 @@ type reconciler struct {
 }
 
 func (r *reconciler) reconcile(ctx context.Context, binding *kubebindv1alpha1.APIServiceBinding) error {
-	logger := klog.FromContext(ctx)
-
 	var errs []error
-	var kubeconfig string
-
-	ref := binding.Spec.KubeconfigSecretRef
-	secret, err := r.getSecret(ref.Namespace, ref.Name)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	} else if errors.IsNotFound(err) {
-		logger.V(2).Info("secret not found", "secret", ref.Namespace+"/"+ref.Name)
-	} else {
-		kubeconfig = string(secret.Data[ref.Key])
-	}
-
-	// extract which namespace this kubeconfig points to
-	cfg, err := clientcmd.Load([]byte(kubeconfig))
-	if err != nil {
-		logger.Error(err, "invalid kubeconfig in secret", "namespace", ref.Namespace, "name", ref.Name)
-		return nil // nothing we can do here. The APIServiceBinding Controller will set a condition
-	}
-	kubeContext, found := cfg.Contexts[cfg.CurrentContext]
-	if !found {
-		logger.Error(err, "kubeconfig in secret does not have a current context", "namespace", ref.Namespace, "name", ref.Name)
-		return nil // nothing we can do here. The APIServiceBinding Controller will set a condition
-	}
 
 	// As konnector is running APIServiceBinding controller for each provider cluster,
 	// so each controller should skip others provider's APIServiceBinding object
-	if kubeContext.Namespace != r.providerNamespace {
+	if r.serviceBindingName != binding.Name {
 		return nil
 	}
 

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
@@ -32,11 +32,12 @@ import (
 )
 
 type reconciler struct {
-	consumerSecretRefKey, providerNamespace, serviceBindingName string
+	consumerSecretRefKey, providerNamespace string
 
-	getServiceExport  func(ns string) (*kubebindv1alpha1.APIServiceExport, error)
-	getServiceBinding func(name string) (*kubebindv1alpha1.APIServiceBinding, error)
-	getClusterBinding func(ctx context.Context) (*kubebindv1alpha1.ClusterBinding, error)
+	reconcileServiceBinding func(binding *kubebindv1alpha1.APIServiceBinding) bool
+	getServiceExport        func(ns string) (*kubebindv1alpha1.APIServiceExport, error)
+	getServiceBinding       func(name string) (*kubebindv1alpha1.APIServiceBinding, error)
+	getClusterBinding       func(ctx context.Context) (*kubebindv1alpha1.ClusterBinding, error)
 
 	updateServiceExportStatus func(ctx context.Context, export *kubebindv1alpha1.APIServiceExport) (*kubebindv1alpha1.APIServiceExport, error)
 
@@ -50,7 +51,7 @@ func (r *reconciler) reconcile(ctx context.Context, binding *kubebindv1alpha1.AP
 
 	// As konnector is running APIServiceBinding controller for each provider cluster,
 	// so each controller should skip others provider's APIServiceBinding object
-	if r.serviceBindingName != binding.Name {
+	if !r.reconcileServiceBinding(binding) {
 		return nil
 	}
 

--- a/pkg/konnector/konnector_controller.go
+++ b/pkg/konnector/konnector_controller.go
@@ -109,6 +109,7 @@ func New(
 					namespaceDynamicInformer,
 					serviceBindingDynamicInformer,
 					crdDynamicInformer,
+					secretInformer,
 				)
 			},
 		},

--- a/pkg/konnector/konnector_controller.go
+++ b/pkg/konnector/konnector_controller.go
@@ -97,19 +97,19 @@ func New(
 			getSecret: func(ns, name string) (*corev1.Secret, error) {
 				return secretInformer.Lister().Secrets(ns).Get(name)
 			},
-			newClusterController: func(consumerSecretRefKey, providerNamespace string, providerConfig *rest.Config) (startable, error) {
+			newClusterController: func(consumerSecretRefKey, providerNamespace, serviceBindingName string, providerConfig *rest.Config) (startable, error) {
 				providerConfig = rest.CopyConfig(providerConfig)
 				providerConfig = rest.AddUserAgent(providerConfig, controllerName)
 
 				return cluster.NewController(
 					consumerSecretRefKey,
 					providerNamespace,
+					serviceBindingName,
 					consumerConfig,
 					providerConfig,
 					namespaceDynamicInformer,
 					serviceBindingDynamicInformer,
 					crdDynamicInformer,
-					secretInformer,
 				)
 			},
 		},

--- a/pkg/konnector/konnector_controller.go
+++ b/pkg/konnector/konnector_controller.go
@@ -97,14 +97,14 @@ func New(
 			getSecret: func(ns, name string) (*corev1.Secret, error) {
 				return secretInformer.Lister().Secrets(ns).Get(name)
 			},
-			newClusterController: func(consumerSecretRefKey, providerNamespace, serviceBindingName string, providerConfig *rest.Config) (startable, error) {
+			newClusterController: func(consumerSecretRefKey, providerNamespace string, reconcileServiceBinding func(binding *kubebindv1alpha1.APIServiceBinding) bool, providerConfig *rest.Config) (startable, error) {
 				providerConfig = rest.CopyConfig(providerConfig)
 				providerConfig = rest.AddUserAgent(providerConfig, controllerName)
 
 				return cluster.NewController(
 					consumerSecretRefKey,
 					providerNamespace,
-					serviceBindingName,
+					reconcileServiceBinding,
 					consumerConfig,
 					providerConfig,
 					namespaceDynamicInformer,

--- a/pkg/konnector/konnector_reconcile.go
+++ b/pkg/konnector/konnector_reconcile.go
@@ -38,7 +38,7 @@ type reconciler struct {
 	lock        sync.Mutex
 	controllers map[string]*controllerContext // by service binding name
 
-	newClusterController func(consumerSecretRefKey, providerNamespace string, providerConfig *rest.Config) (startable, error)
+	newClusterController func(consumerSecretRefKey, providerNamespace, serviceBindingName string, providerConfig *rest.Config) (startable, error)
 	getSecret            func(ns, name string) (*corev1.Secret, error)
 }
 
@@ -120,6 +120,7 @@ func (r *reconciler) reconcile(ctx context.Context, binding *kubebindv1alpha1.AP
 	ctrl, err := r.newClusterController(
 		binding.Spec.KubeconfigSecretRef.Namespace+"/"+binding.Spec.KubeconfigSecretRef.Name,
 		providerNamespace,
+		binding.Name,
 		providerConfig,
 	)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Pulak Kanti Bhowmick <pulak@appscode.com>

Fix #140 

As konnector is running APIServiceBinding controller for each provider cluster, so each controller should skip others provider's APIServiceBinding object.