### PR TITLE
Remove duplicate event handler from informer

### DIFF
--- a/pkg/konnector/controllers/servicebinding/servicebinding_controller.go
+++ b/pkg/konnector/controllers/servicebinding/servicebinding_controller.go
@@ -119,18 +119,6 @@ func NewController(
 		},
 	})
 
-	consumerSecretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			c.enqueueConsumerSecret(logger, obj)
-		},
-		UpdateFunc: func(_, newObj interface{}) {
-			c.enqueueConsumerSecret(logger, newObj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			c.enqueueConsumerSecret(logger, obj)
-		},
-	})
-
 	return c, nil
 }
 


### PR DESCRIPTION
The event handler on the consumer secrets informer (in the konnector's APIServiceBinding controller) was registered twice, this PR removes the second (unneeded) occurrence.

See the lines right above the removed ones to verify that the event handler is already registered.