### PR TITLE
Remove unused CRD lister and indexer from konnector's controller

### DIFF
--- a/pkg/konnector/controllers/servicebinding/servicebinding_controller.go
+++ b/pkg/konnector/controllers/servicebinding/servicebinding_controller.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
-	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -52,7 +50,6 @@ func NewController(
 	consumerConfig *rest.Config,
 	serviceBindingInformer bindinformers.APIServiceBindingInformer,
 	consumerSecretInformer coreinformers.SecretInformer,
-	crdInformer apiextensionsinformers.CustomResourceDefinitionInformer,
 ) (*controller, error) {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName)
 
@@ -73,9 +70,6 @@ func NewController(
 		serviceBindingIndexer: serviceBindingInformer.Informer().GetIndexer(),
 
 		consumerSecretLister: consumerSecretInformer.Lister(),
-
-		crdLister:  crdInformer.Lister(),
-		crdIndexer: crdInformer.Informer().GetIndexer(),
 
 		reconciler: reconciler{
 			getConsumerSecret: func(ns, name string) (*corev1.Secret, error) {
@@ -135,9 +129,6 @@ type controller struct {
 	serviceBindingIndexer cache.Indexer
 
 	consumerSecretLister corelisters.SecretLister
-
-	crdLister  apiextensionslisters.CustomResourceDefinitionLister
-	crdIndexer cache.Indexer
 
 	reconciler
 

--- a/pkg/konnector/konnector_controller.go
+++ b/pkg/konnector/konnector_controller.go
@@ -70,7 +70,7 @@ func New(
 		return nil, err
 	}
 
-	servicebindingCtrl, err := servicebinding.NewController(consumerConfig, serviceBindingInformer, secretInformer, crdInformer)
+	servicebindingCtrl, err := servicebinding.NewController(consumerConfig, serviceBindingInformer, secretInformer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove the unused CRD lister and indexer from the konnector's APIServiceBinding controller that reconciles kubeconfig secrets. They had been added by mistake and aren't needed.

This change was agreed upon [here](https://github.com/kube-bind/kube-bind/pull/149#issuecomment-1410870035).