### PR TITLE
pkg/kubectl: remove unused urlCh

### DIFF
--- a/pkg/kubectl/bind/cmd/cmd.go
+++ b/pkg/kubectl/bind/cmd/cmd.go
@@ -82,7 +82,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 				return err
 			}
 
-			return opts.Run(cmd.Context(), nil)
+			return opts.Run(cmd.Context())
 		},
 	}
 	opts.AddCmdFlags(cmd)

--- a/pkg/kubectl/bind/plugin/authenticate.go
+++ b/pkg/kubectl/bind/plugin/authenticate.go
@@ -91,7 +91,7 @@ func validateProviderVersion(providerVersion string) error {
 	return nil
 }
 
-func (b *BindOptions) authenticate(provider *kubebindv1alpha1.BindingProvider, callback, sessionID, clusterID string, urlCh chan<- string) error {
+func (b *BindOptions) authenticate(provider *kubebindv1alpha1.BindingProvider, callback, sessionID, clusterID string) error {
 	var oauth2Method *kubebindv1alpha1.OAuth2CodeGrant
 	for _, m := range provider.AuthenticationMethods {
 		if m.Method == "OAuth2CodeGrant" {
@@ -136,9 +136,6 @@ func (b *BindOptions) authenticate(provider *kubebindv1alpha1.BindingProvider, c
 			QuietZone: 2,
 		}
 		qrterminal.GenerateWithConfig(u.String(), config)
-	}
-	if urlCh != nil {
-		urlCh <- u.String()
 	}
 
 	return nil

--- a/pkg/kubectl/bind/plugin/bind.go
+++ b/pkg/kubectl/bind/plugin/bind.go
@@ -131,7 +131,7 @@ func (b *BindOptions) Validate() error {
 }
 
 // Run starts the binding process.
-func (b *BindOptions) Run(ctx context.Context, urlCh chan<- string) error {
+func (b *BindOptions) Run(ctx context.Context) error {
 	config, err := b.ClientConfig.ClientConfig()
 	if err != nil {
 		return err
@@ -179,7 +179,7 @@ func (b *BindOptions) Run(ctx context.Context, urlCh chan<- string) error {
 	}
 
 	sessionID := SessionID()
-	if err := b.authenticate(provider, auth.Endpoint(), sessionID, ClusterID(ns), urlCh); err != nil {
+	if err := b.authenticate(provider, auth.Endpoint(), sessionID, ClusterID(ns)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The `urlCh` is a remainder of a previous implementation. It is currently unused, hence let's remove it. Passing channels over so many layers is probably not a good idea in the first place.

/cc @sttts 