### PR TITLE
Fix error message: print correct got type

### DIFF
--- a/deploy/crd/bootstrap.go
+++ b/deploy/crd/bootstrap.go
@@ -114,7 +114,7 @@ func CRD(fs embed.FS, gr metav1.GroupResource) (*apiextensionsv1.CustomResourceD
 
 	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
 	if !ok {
-		return nil, fmt.Errorf("decoded CRD %s into incorrect type, got %T, wanted %T", gr.String(), crd, &apiextensionsv1.CustomResourceDefinition{})
+		return nil, fmt.Errorf("decoded CRD %s into incorrect type, got %T, wanted %T", gr.String(), obj, &apiextensionsv1.CustomResourceDefinition{})
 	}
 
 	return crd, nil


### PR DESCRIPTION
Fix the message of the error returned when a decoded object that's expected to be a CRD isn't a CRD (in the code that installs the CRDs in the K8s cluster).

The message printed the wrong got type, this PR makes it print the right got type.