### PR TITLE
Fixes to the 'kube-binder' clusterrole

### DIFF
--- a/cmd/example-backend/main.go
+++ b/cmd/example-backend/main.go
@@ -52,7 +52,7 @@ func main() {
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting example-backend", "version", ver)
 
-	// craate server
+	// create server
 	completed, err := options.Complete()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v", err) // nolint: errcheck

--- a/contrib/example-backend/controllers/clusterbinding/clusterbinding_reconcile.go
+++ b/contrib/example-backend/controllers/clusterbinding/clusterbinding_reconcile.go
@@ -234,7 +234,7 @@ func (r *reconciler) ensureRBACClusterRoleBinding(ctx context.Context, clusterBi
 func (r *reconciler) ensureRBACRoleBinding(ctx context.Context, clusterBinding *kubebindv1alpha1.ClusterBinding) error {
 	binding, err := r.getRoleBinding(clusterBinding.Namespace, "kube-binder")
 	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to get RoleBinding \"kube-bind\": %w", err)
+		return fmt.Errorf("failed to get RoleBinding \"kube-binder\": %w", err)
 	}
 
 	expected := &rbacv1.RoleBinding{

--- a/contrib/example-backend/deploy/01-clusterrole.yaml
+++ b/contrib/example-backend/deploy/01-clusterrole.yaml
@@ -38,8 +38,3 @@ rules:
   resources:
     - "apiservicenamespaces"
   verbs: ["create","delete","patch","update","get","list","watch"]
-- apiGroups:
-    - "kube-bind.io"
-  resources:
-    - "apiservicenamespaces"
-  verbs: ["create","delete","patch","update","get","list","watch"]

--- a/pkg/konnector/controllers/cluster/serviceexport/serviceexport_reconcile.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/serviceexport_reconcile.go
@@ -123,7 +123,7 @@ func (r *reconciler) ensureControllers(ctx context.Context, name string, export 
 		r.lock.Lock()
 		defer r.lock.Unlock()
 		if c, found := r.syncContext[export.Name]; found {
-			logger.V(1).Info("Stopping APIServiceExport sync", "reason", "NoAPIServiceExport")
+			logger.V(1).Info("Stopping APIServiceExport sync", "reason", "NoAPIServiceBinding")
 			c.cancel()
 			delete(r.syncContext, export.Name)
 		}

--- a/pkg/kubectl/bind-apiservice/cmd/cmd.go
+++ b/pkg/kubectl/bind-apiservice/cmd/cmd.go
@@ -38,7 +38,7 @@ var (
 	# bind to a remote API service via a request manifest from a https URL.
 	%[1]s apiservice --remote-kubeconfig file https://some-url.com/apiservice-export-requests.yaml
 
-    # bind to a API service directly without any remote agent or service provider.
+	# bind to a API service directly without any remote agent or service provider.
 	%[1]s apiservice --remote-kubeconfig file -n remote-namespace resources.group/v1
 	`
 )

--- a/pkg/kubectl/bind/cmd/cmd.go
+++ b/pkg/kubectl/bind/cmd/cmd.go
@@ -34,7 +34,7 @@ import (
 var (
 	// TODO: add other examples related to permission claim commands.
 	bindExampleUses = `
-    # select a kube-bind.io compatible service from the given URL, e.g. an API service.
+	# select a kube-bind.io compatible service from the given URL, e.g. an API service.
 	%[1]s bind https://mangodb.com/exports
 
 	# authenticate and configure the services to bind, but don't actually bind them.


### PR DESCRIPTION
This PR tries to improve on two things.

1. The access to apiservicenamespaces seems to be defined twice.
```
👉 Downloads $ kubectl get clusterrole kube-binder -oyaml | tail -n 24
- apiGroups:
  - kube-bind.io
  resources:
  - apiservicenamespaces
  verbs:
  - create
  - delete
  - patch
  - update
  - get
  - list
  - watch
- apiGroups:
  - kube-bind.io
  resources:
  - apiservicenamespaces
  verbs:
  - create
  - delete
  - patch
  - update
  - get
  - list
  - watch
```
This PR tries to fix it by cleaning up the bootstrapping manifest.

2. Some typo fixes.