### PR TITLE
Fix enqueue functions of the status controller

### DIFF
--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -190,19 +190,19 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj interface{}) {
 }
 
 func (c *controller) enqueueConsumer(logger klog.Logger, obj interface{}) {
-	upstreamKey, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	downstreamKey, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	ns, name, err := cache.SplitMetaNamespaceKey(upstreamKey)
+	ns, name, err := cache.SplitMetaNamespaceKey(downstreamKey)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
 
 	if ns != "" {
-		sn, err := c.serviceNamespaceInformer.Lister().APIServiceNamespaces(ns).Get(name)
+		sn, err := c.serviceNamespaceInformer.Lister().APIServiceNamespaces(c.providerNamespace).Get(ns)
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				runtime.HandleError(err)
@@ -218,8 +218,8 @@ func (c *controller) enqueueConsumer(logger klog.Logger, obj interface{}) {
 		return
 	}
 
-	logger.V(2).Info("queueing Unstructured", "key", upstreamKey)
-	c.queue.Add(upstreamKey)
+	logger.V(2).Info("queueing Unstructured", "key", downstreamKey)
+	c.queue.Add(downstreamKey)
 }
 
 func (c *controller) enqueueServiceNamespace(logger klog.Logger, obj interface{}) {

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -187,6 +187,9 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj interface{}) {
 		}
 		logger.V(3).Info("skipping because consumer mismatch", "key", key)
 	}
+
+	logger.V(2).Info("queueing Unstructured", "key", key)
+	c.queue.Add(key)
 }
 
 func (c *controller) enqueueConsumer(logger klog.Logger, obj interface{}) {


### PR DESCRIPTION
This PR introduces two fixes to the status controller. I arrange the them as two separate commits for easier review.

### The first commit
The first commit fixes `enqueueConsumer` of the status controller, for namespaced objects.

To check the corresponding APIServiceNamespace, we need
- its namespace which should be the 'cluster namespace' shown in the [Technical Overview](https://github.com/kube-bind/kube-bind#technical-overview). Or in other words, the `c.providerNamespace` in the code;
- its name which is the same as the namespace that holds the incoming object in the consumer cluster.

From other places of the code, looks like 'upstream' is used to refer to the provider and 'downstream' to the consumer. So I also renamed the variable `upstreamKey`. Please correct me if I am wrong.

### The second commit
The second commit fixes `enqueueProvider` of the status controller, for cluster-scoped objects.

We have a total of 4 enqueue functions in the syncer, including an `enqueueConsumer` and an `enqueueProvider` of the spec controller, and similar two functions of the status controller.

All of the enqueue functions enqueue cluster-scoped objects, except the `enqueueProvider` of the status controller. So I added that to the function to make it consistent with the other 3 functions.