### PR TITLE
konnector/namespacedeletion: correctly map local namespace to APIServiceNamespace

### DIFF
--- a/pkg/konnector/controllers/cluster/cluster_controller.go
+++ b/pkg/konnector/controllers/cluster/cluster_controller.go
@@ -117,6 +117,7 @@ func NewController(
 	}
 	namespacedeletionCtrl, err := namespacedeletion.NewController(
 		providerConfig,
+		providerNamespace,
 		providerBindInformers.KubeBind().V1alpha1().APIServiceNamespaces(),
 		namespaceInformer,
 	)


### PR DESCRIPTION
The key lacked the provider namespace.