### PR TITLE
Add supports to cluster-scoped APIs

### DIFF
--- a/contrib/example-backend/deploy/01-clusterrole.yaml
+++ b/contrib/example-backend/deploy/01-clusterrole.yaml
@@ -11,6 +11,11 @@ rules:
 - apiGroups:
     - ""
   resources:
+    - "namespaces"
+  verbs: ["get"]
+- apiGroups:
+    - ""
+  resources:
     - "secrets"
   verbs: ["get", "watch", "list"]
 - apiGroups:

--- a/pkg/konnector/controllers/cluster/serviceexport/cluster-scoped/utils.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/cluster-scoped/utils.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2023 The Kube Bind Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterscoped
+
+import (
+	"errors"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ClusterNsAnnotationKey is the annotation key to identify the cluster namespace that corresponds to
+// provider side copy of a cluster-scoped object. Its value is the corresponding cluster namespace name.
+const ClusterNsAnnotationKey = "kube-bind.io/cluster-namespace"
+
+// Prepend adds clusterNs and a dash before name.
+func Prepend(name, clusterNs string) string {
+	return clusterNs + "-" + name
+}
+
+// Behead tries to remove clusterNs and a dash that goes before name.
+// If name doesn't start with clusterNs, name is returned unchanged.
+func Behead(name, clusterNs string) string {
+	return strings.TrimPrefix(name, clusterNs+"-")
+}
+
+// SwitchToUpstreamName switches the name of a downstream
+// cluster-scoped object by prepending the cluster namespace name.
+func SwitchToUpstreamName(obj *unstructured.Unstructured, clusterNs string) {
+	downstreamName := obj.GetName()
+	upstreamName := Prepend(downstreamName, clusterNs)
+	obj.SetName(upstreamName)
+}
+
+// SwitchToDownstreamName switches the name of a upstream
+// cluster-scoped object by removing the cluster namespace name as the prefix.
+func SwitchToDownstreamName(obj *unstructured.Unstructured, clusterNs string) {
+	upstreamName := obj.GetName()
+	downstreamName := Behead(upstreamName, clusterNs)
+	obj.SetName(downstreamName)
+}
+
+// InjectClusterNs injects the given cluster namespace (1) as an annotation,
+// and (2) as a owner reference to the cluster namespace.
+func InjectClusterNs(obj *unstructured.Unstructured, clusterNs, clusterNsUID string) error {
+	ans := obj.GetAnnotations()
+	existing, foundAn := ans[ClusterNsAnnotationKey]
+	if foundAn && existing != clusterNs {
+		return errors.New("mismatch between existing cluster namespace and given cluster namespace")
+	}
+
+	ors := obj.GetOwnerReferences()
+	idx, foundOr := findOwnerReferenceToClusterNs(ors, clusterNs)
+	if foundOr && ors[idx].Name != clusterNs {
+		return errors.New("mismatch between existing cluster namespace and given cluster namespace")
+	}
+
+	if !foundAn {
+		if ans == nil {
+			ans = map[string]string{}
+		}
+		ans[ClusterNsAnnotationKey] = clusterNs
+		obj.SetAnnotations(ans)
+	}
+
+	if !foundOr {
+		ors = append(ors, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       clusterNs,
+			UID:        types.UID(clusterNsUID),
+		})
+		obj.SetOwnerReferences(ors)
+	}
+
+	return nil
+}
+
+// ExtractClusterNs extracts the corresponding cluster namespace name
+// from a cluster-scoped object by reading the annotation.
+func ExtractClusterNs(obj *unstructured.Unstructured) (string, error) {
+	ans := obj.GetAnnotations()
+	clusterNs, ok := ans[ClusterNsAnnotationKey]
+	if !ok {
+		return "", errors.New("cluster namespace annotation not found")
+	}
+	return clusterNs, nil
+}
+
+// ClearClusterNs clears the given cluster namespace in a cluster-scoped object,
+// including both the annotation and the owner reference.
+func ClearClusterNs(obj *unstructured.Unstructured, clusterNs string) error {
+	ans := obj.GetAnnotations()
+	delete(ans, ClusterNsAnnotationKey)
+	obj.SetAnnotations(ans)
+
+	ors := obj.GetOwnerReferences()
+	idx, foundOr := findOwnerReferenceToClusterNs(ors, clusterNs)
+	if foundOr {
+		ors[idx] = ors[len(ors)-1]
+		ors = ors[:len(ors)-1]
+		obj.SetOwnerReferences(ors)
+	}
+
+	return nil
+}
+
+func TranslateFromDownstream(obj *unstructured.Unstructured, clusterNs, clusterNsUID string) (*unstructured.Unstructured, error) {
+	err := InjectClusterNs(obj, clusterNs, clusterNsUID)
+	if err != nil {
+		return nil, err
+	}
+	SwitchToUpstreamName(obj, clusterNs)
+	return obj, nil
+}
+
+func TranslateFromUpstream(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	clusterNs, err := ExtractClusterNs(obj)
+	if err != nil {
+		return nil, err
+	}
+	err = ClearClusterNs(obj, clusterNs)
+	if err != nil {
+		return nil, err
+	}
+	SwitchToDownstreamName(obj, clusterNs)
+	return obj, nil
+}
+
+func findOwnerReferenceToClusterNs(ors []metav1.OwnerReference, clusterNs string) (int, bool) {
+	if ors == nil {
+		return -1, false
+	}
+	for i, or := range ors {
+		if or.Kind == "Namespace" && or.Name == clusterNs {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/pkg/konnector/controllers/cluster/serviceexport/cluster-scoped/utils_test.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/cluster-scoped/utils_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2023 The Kube Bind Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterscoped
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestSwitchToUpstreamName(t *testing.T) {
+	tests := []struct {
+		name      string
+		clusterNs string
+		down      string
+		expected  string
+	}{
+		{
+			name:      "2up",
+			clusterNs: "kube-bind-zlp9m",
+			down:      "example-foo",
+			expected:  "kube-bind-zlp9m-example-foo",
+		},
+	}
+	for _, tt := range tests {
+		obj := unstructured.Unstructured{}
+		obj.SetName(tt.down)
+		SwitchToUpstreamName(&obj, tt.clusterNs)
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := obj.GetName(); actual != tt.expected {
+				t.Error("SwitchToUpstreamName() error", "expected", tt.expected, "actual", actual)
+			}
+		})
+	}
+}
+
+func TestSwitchToDownstreamName(t *testing.T) {
+	tests := []struct {
+		name      string
+		clusterNs string
+		up        string
+		expected  string
+	}{
+		{
+			name:      "2down",
+			clusterNs: "kube-bind-zlp9m",
+			up:        "kube-bind-zlp9m-example-foo",
+			expected:  "example-foo",
+		},
+	}
+	for _, tt := range tests {
+		obj := unstructured.Unstructured{}
+		obj.SetName(tt.up)
+		SwitchToDownstreamName(&obj, tt.clusterNs)
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := obj.GetName(); actual != tt.expected {
+				t.Error("SwitchToUpstreamName() error", "expected", tt.expected, "actual", actual)
+			}
+		})
+	}
+}
+
+func TestInjectClusterNs(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          unstructured.Unstructured
+		clusterNs    string
+		clusterNsUID string
+		expected     string
+		wantErr      bool
+	}{
+		{
+			name:         "noExistingClusterNs",
+			obj:          unstructured.Unstructured{},
+			clusterNs:    "kube-bind-zlp9m",
+			clusterNsUID: "real-identity",
+			expected:     "kube-bind-zlp9m",
+			wantErr:      false,
+		},
+		{
+			name:         "oneExistingClusterNs",
+			obj:          newObjectWithClusterNs("kube-bind-zlp9m"),
+			clusterNs:    "kube-bind-s85lc",
+			clusterNsUID: "real-indentity",
+			expected:     "kube-bind-zlp9m",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := InjectClusterNs(&tt.obj, tt.clusterNs, tt.clusterNsUID); (err != nil) != tt.wantErr {
+				actual := tt.obj.GetAnnotations()[ClusterNsAnnotationKey]
+				t.Error("InjectClusterNs() error", "error", err, "expected", tt.expected, "actual", actual)
+			} else if err == nil {
+				actual := tt.obj.GetAnnotations()[ClusterNsAnnotationKey]
+				require.Equal(t, tt.expected, actual)
+			} else {
+				t.Log("expected error", err)
+			}
+		})
+	}
+}
+
+func TestExtractClusterNs(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      unstructured.Unstructured
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "oneExistingClusterNs",
+			obj:      newObjectWithClusterNs("kube-bind-zlp9m"),
+			expected: "kube-bind-zlp9m",
+			wantErr:  false,
+		},
+		{
+			name:     "noExistingClusterNs",
+			obj:      unstructured.Unstructured{},
+			expected: "",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual, err := ExtractClusterNs(&tt.obj); (err != nil) != tt.wantErr {
+				t.Error("ExtractClusterNs() error", "error", err, "expected", tt.expected, "actual", actual)
+			} else if err == nil {
+				require.Equal(t, tt.expected, actual)
+			} else {
+				t.Log("expected error", err)
+			}
+		})
+	}
+}
+
+func TestClearClusterNs(t *testing.T) {
+	tests := []struct {
+		name      string
+		obj       unstructured.Unstructured
+		clusterNs string
+		expected  int
+		wantErr   bool
+	}{
+		{
+			name:      "oneExistingClusterNs",
+			obj:       newObjectWithClusterNs("kube-bind-zlp9m"),
+			clusterNs: "kube-bind-zlp9m",
+			expected:  0,
+			wantErr:   false,
+		},
+		{
+			name:      "noExistingClusterNs",
+			obj:       unstructured.Unstructured{},
+			clusterNs: "not-applicable",
+			expected:  0,
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ClearClusterNs(&tt.obj, tt.clusterNs); (err != nil) != tt.wantErr {
+				actual := len(tt.obj.GetOwnerReferences())
+				t.Error("ClearClusterNs() error", "error", err, "expected", tt.expected, "actual", actual)
+			} else if err == nil {
+				actual := len(tt.obj.GetOwnerReferences())
+				require.Equal(t, tt.expected, actual)
+			} else {
+				t.Log("expected error", err)
+			}
+		})
+	}
+}
+
+func newObjectWithClusterNs(name string) unstructured.Unstructured {
+	obj := unstructured.Unstructured{}
+	ans := map[string]string{
+		ClusterNsAnnotationKey: name,
+	}
+	obj.SetAnnotations(ans)
+	ors := []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+		Name:       name,
+	}}
+	obj.SetOwnerReferences(ors)
+	return obj
+}

--- a/pkg/konnector/controllers/cluster/serviceexport/multinsinformer/informer.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/multinsinformer/informer.go
@@ -287,7 +287,11 @@ type GetterInformerWrapper struct {
 }
 
 func (w GetterInformerWrapper) Get(ns, name string) (runtime.Object, error) {
-	return w.Delegate.ForResource(w.GVR).Lister().ByNamespace(ns).Get(name)
+	if ns != "" {
+		return w.Delegate.ForResource(w.GVR).Lister().ByNamespace(ns).Get(name)
+	} else {
+		return w.Delegate.ForResource(w.GVR).Lister().Get(name)
+	}
 }
 
 func (w GetterInformerWrapper) List(ns string) ([]runtime.Object, error) {

--- a/pkg/konnector/controllers/cluster/serviceexport/multinsinformer/informer.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/multinsinformer/informer.go
@@ -289,9 +289,8 @@ type GetterInformerWrapper struct {
 func (w GetterInformerWrapper) Get(ns, name string) (runtime.Object, error) {
 	if ns != "" {
 		return w.Delegate.ForResource(w.GVR).Lister().ByNamespace(ns).Get(name)
-	} else {
-		return w.Delegate.ForResource(w.GVR).Lister().Get(name)
 	}
+	return w.Delegate.ForResource(w.GVR).Lister().Get(name)
 }
 
 func (w GetterInformerWrapper) List(ns string) ([]runtime.Object, error) {

--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
@@ -332,7 +332,12 @@ func (c *controller) process(ctx context.Context, key string) error {
 
 	logger := klog.FromContext(ctx)
 
-	obj, err := c.consumerDynamicLister.Namespace(ns).Get(name)
+	var obj *unstructured.Unstructured
+	if ns == "" {
+		obj, err = c.consumerDynamicLister.Get(name)
+	} else {
+		obj, err = c.consumerDynamicLister.Namespace(ns).Get(name)
+	}
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	} else if errors.IsNotFound(err) {

--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
@@ -263,6 +263,10 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj interface{}) {
 		return
 	}
 
+	if clusterscoped.Behead(upstreamKey, c.providerNamespace) == upstreamKey {
+		logger.V(3).Info("skipping because consumer mismatch", "upstreamKey", upstreamKey)
+		return
+	}
 	downstreamKey := clusterscoped.Behead(upstreamKey, c.providerNamespace)
 	logger.V(2).Info("queueing Unstructured", "key", downstreamKey)
 	c.queue.Add(downstreamKey)

--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
@@ -227,8 +227,9 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj interface{}) {
 		return
 	}
 
-	logger.V(2).Info("queueing Unstructured", "key", upstreamKey)
-	c.queue.Add(upstreamKey)
+	downstreamKey := clusterscoped.Behead(upstreamKey, c.providerNamespace)
+	logger.V(2).Info("queueing Unstructured", "key", downstreamKey)
+	c.queue.Add(downstreamKey)
 }
 
 func (c *controller) enqueueServiceNamespace(logger klog.Logger, obj interface{}) {

--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
@@ -56,6 +56,7 @@ const (
 func NewController(
 	gvr schema.GroupVersionResource,
 	providerNamespace string,
+	providerNamespaceUID string,
 	consumerConfig, providerConfig *rest.Config,
 	consumerDynamicInformer informers.GenericInformer,
 	providerDynamicInformer multinsinformer.GetterInformer,

--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_reconcile.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_reconcile.go
@@ -152,7 +152,7 @@ func (r *reconciler) reconcile(ctx context.Context, obj *unstructured.Unstructur
 	}
 	upstreamSpec, _, err := unstructured.NestedFieldNoCopy(upstream.Object, "spec")
 	if err != nil {
-		logger.Error(err, "failed to get downstream spec")
+		logger.Error(err, "failed to get upstream spec")
 		return nil
 	}
 	if reflect.DeepEqual(downstreamSpec, upstreamSpec) {
@@ -174,7 +174,7 @@ func (r *reconciler) reconcile(ctx context.Context, obj *unstructured.Unstructur
 		unstructured.RemoveNestedField(upstream.Object, "spec")
 	}
 
-	logger.Info("Updating update object")
+	logger.Info("Updating upstream object")
 	upstream.SetManagedFields(nil) // server side apply does not want this
 	if _, err := r.updateProviderObject(ctx, upstream); err != nil {
 		return err

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -50,6 +50,7 @@ const (
 func NewController(
 	gvr schema.GroupVersionResource,
 	providerNamespace string,
+	providerNamespaceUID string,
 	consumerConfig, providerConfig *rest.Config,
 	consumerDynamicInformer informers.GenericInformer,
 	providerDynamicInformer multinsinformer.GetterInformer,

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -210,6 +210,10 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj interface{}) {
 		return
 	}
 
+	if clusterscoped.Behead(key, c.providerNamespace) == key {
+		logger.V(3).Info("skipping because consumer mismatch", "key", key)
+		return
+	}
 	logger.V(2).Info("queueing Unstructured", "key", key)
 	c.queue.Add(key)
 }

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -227,8 +227,9 @@ func (c *controller) enqueueConsumer(logger klog.Logger, obj interface{}) {
 		return
 	}
 
-	logger.V(2).Info("queueing Unstructured", "key", downstreamKey)
-	c.queue.Add(downstreamKey)
+	upstreamKey := clusterscoped.Prepend(downstreamKey, c.providerNamespace)
+	logger.V(2).Info("queueing Unstructured", "key", upstreamKey)
+	c.queue.Add(upstreamKey)
 }
 
 func (c *controller) enqueueServiceNamespace(logger klog.Logger, obj interface{}) {

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -104,7 +104,11 @@ func NewController(
 				return sns[0].(*kubebindv1alpha1.APIServiceNamespace), nil
 			},
 			getConsumerObject: func(ns, name string) (*unstructured.Unstructured, error) {
-				return dynamicConsumerLister.Namespace(ns).Get(name)
+				if ns != "" {
+					return dynamicConsumerLister.Namespace(ns).Get(name)
+				} else {
+					return dynamicConsumerLister.Get(name)
+				}
 			},
 			updateConsumerObjectStatus: func(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 				return consumerClient.Resource(gvr).Namespace(obj.GetNamespace()).UpdateStatus(ctx, obj, metav1.UpdateOptions{})

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_reconcile.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_reconcile.go
@@ -92,7 +92,7 @@ func (r *reconciler) reconcile(ctx context.Context, obj *unstructured.Unstructur
 		unstructured.RemoveNestedField(downstream.Object, "status")
 	}
 	if !reflect.DeepEqual(orig, downstream) {
-		logger.Info("Updating downstream object status", "downstreamNamespace", ns, "downstreamName", obj.GetName())
+		logger.Info("Updating downstream object status")
 		if _, err := r.updateConsumerObjectStatus(ctx, downstream); err != nil {
 			return err
 		}

--- a/test/e2e/bind/fixtures/provider/crd-foo.yaml
+++ b/test/e2e/bind/fixtures/provider/crd-foo.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.bar.io
+  labels:
+    kube-bind.io/exported: "true"
+spec:
+  group: bar.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        # schema used for validation
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                deploymentName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+            status:
+              type: object
+              properties:
+                availableReplicas:
+                  type: integer
+                phase:
+                  type: string
+                  enum:
+                  - Pending
+                  - Running
+                  - Succeeded
+                  - Failed
+                  - Unknown
+      # subresources for the custom resource
+      subresources:
+        # enables the status subresource
+        status: {}
+  names:
+    kind: Foo
+    plural: foos
+  scope: Cluster


### PR DESCRIPTION
This PR tries to do two things regarding cluster-scoped APIs.
1. Completely enable the exporting and syncing of cluster-scoped APIs. As mentioned by @sttts in the [slack channel](https://kubernetes.slack.com/archives/C046PRXNJ4W/p1689088717859549?thread_ts=1688665656.221059&cid=C046PRXNJ4W), the exporting of cluster-scoped APIs is almost working. Some small tweaks are added in 934bda0 to make it complete.
2. Resolve the name conflicts for cluster-scoped API objects. Most work of the PR is for this second thing. To do that, a shim is implemented to a) translate between consumer side object names and provider side object names, b) filter object names for individual consumers. I came up with a diagram to make it easier to be reviewed. The shim is represented by the black curve in the middle of the diagram (feel free to click to zoom-in or visit the [original drawing](https://docs.google.com/drawings/d/1DH609qJW8uAuowmMx2Bo957edRJ4Mv0_BzLPmLbiX6U/)):

<img width="1429" alt="image" src="https://github.com/kube-bind/kube-bind/assets/8633434/e6eeb45d-eef5-4169-b1c3-4d4344ed05dc">

This PR doesn't resolve the permission question, as discussed [in this thread](https://kubernetes.slack.com/archives/C046PRXNJ4W/p1689088050065169?thread_ts=1688665656.221059&cid=C046PRXNJ4W). But the point is well taken. Looks like something like node authorizer is a way to go, and I'm happy to continue working on that.