### PR TITLE
Add ClusterScopedIsolation to APIServiceExportSpec

### DIFF
--- a/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_controller.go
+++ b/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_controller.go
@@ -52,6 +52,7 @@ const (
 func NewController(
 	config *rest.Config,
 	scope kubebindv1alpha1.Scope,
+	isolation kubebindv1alpha1.Isolation,
 	serviceExportRequestInformer bindinformers.APIServiceExportRequestInformer,
 	serviceExportInformer bindinformers.APIServiceExportInformer,
 	crdInformer apiextensionsinformers.CustomResourceDefinitionInformer,
@@ -88,7 +89,8 @@ func NewController(
 		crdIndexer: crdInformer.Informer().GetIndexer(),
 
 		reconciler: reconciler{
-			informerScope: scope,
+			informerScope:          scope,
+			clusterScopedIsolation: isolation,
 			getCRD: func(name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 				return crdInformer.Lister().Get(name)
 			},

--- a/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
+++ b/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
@@ -113,7 +113,7 @@ func (r *reconciler) ensureExports(ctx context.Context, req *kubebindv1alpha1.AP
 					InformerScope:           r.informerScope,
 				},
 			}
-			if r.informerScope == kubebindv1alpha1.ClusterScope {
+			if exportSpec.Scope == apiextensionsv1.ClusterScoped {
 				export.Spec.ClusterScopedIsolation = r.clusterScopedIsolation
 			}
 

--- a/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
+++ b/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
@@ -111,8 +111,10 @@ func (r *reconciler) ensureExports(ctx context.Context, req *kubebindv1alpha1.AP
 				Spec: kubebindv1alpha1.APIServiceExportSpec{
 					APIServiceExportCRDSpec: *exportSpec,
 					InformerScope:           r.informerScope,
-					ClusterScopedIsolation:  r.clusterScopedIsolation,
 				},
+			}
+			if r.informerScope == kubebindv1alpha1.ClusterScope {
+				export.Spec.ClusterScopedIsolation = r.clusterScopedIsolation
 			}
 
 			logger.V(1).Info("Creating APIServiceExport", "name", export.Name, "namespace", export.Namespace)

--- a/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
+++ b/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
@@ -33,7 +33,8 @@ import (
 )
 
 type reconciler struct {
-	informerScope kubebindv1alpha1.Scope
+	informerScope          kubebindv1alpha1.Scope
+	clusterScopedIsolation kubebindv1alpha1.Isolation
 
 	getCRD              func(name string) (*apiextensionsv1.CustomResourceDefinition, error)
 	getServiceExport    func(ns, name string) (*kubebindv1alpha1.APIServiceExport, error)
@@ -110,6 +111,7 @@ func (r *reconciler) ensureExports(ctx context.Context, req *kubebindv1alpha1.AP
 				Spec: kubebindv1alpha1.APIServiceExportSpec{
 					APIServiceExportCRDSpec: *exportSpec,
 					InformerScope:           r.informerScope,
+					ClusterScopedIsolation:  r.clusterScopedIsolation,
 				},
 			}
 

--- a/contrib/example-backend/options/options.go
+++ b/contrib/example-backend/options/options.go
@@ -41,13 +41,14 @@ type Options struct {
 type ExtraOptions struct {
 	KubeConfig string
 
-	NamespacePrefix       string
-	PrettyName            string
-	ConsumerScope         string
-	ExternalAddress       string
-	ExternalCAFile        string
-	ExternalCA            []byte
-	TLSExternalServerName string
+	NamespacePrefix        string
+	PrettyName             string
+	ConsumerScope          string
+	ClusterScopedIsolation string
+	ExternalAddress        string
+	ExternalCAFile         string
+	ExternalCA             []byte
+	TLSExternalServerName  string
 
 	TestingAutoSelect string
 }
@@ -77,9 +78,10 @@ func NewOptions() *Options {
 		Serve:  NewServe(),
 
 		ExtraOptions: ExtraOptions{
-			NamespacePrefix: "cluster",
-			PrettyName:      "Example Backend",
-			ConsumerScope:   string(kubebindv1alpha1.NamespacedScope),
+			NamespacePrefix:        "cluster",
+			PrettyName:             "Example Backend",
+			ConsumerScope:          string(kubebindv1alpha1.NamespacedScope),
+			ClusterScopedIsolation: string(kubebindv1alpha1.IsolationPrefixed),
 		},
 	}
 }
@@ -94,6 +96,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.NamespacePrefix, "namespace-prefix", options.NamespacePrefix, "The prefix to use for cluster namespaces")
 	fs.StringVar(&options.PrettyName, "pretty-name", options.PrettyName, "Pretty name for the backend")
 	fs.StringVar(&options.ConsumerScope, "consumer-scope", options.ConsumerScope, "How consumers access the service provider cluster. In Kubernetes, \"namespaced\" allows namespace isolation. In kcp, \"cluster\" allows workspace isolation, and with that allows cluster-scoped resources to bind and it is generally more performant.")
+	fs.StringVar(&options.ClusterScopedIsolation, "cluster-scoped-isolation", options.ClusterScopedIsolation, "How cluster scoped service objects are isolated between multiple consumers on the provider side. Among the choices, \"prefixed\" prepends the name of the cluster namespace to an object's name; \"namespaced\" maps a consumer side object into a namespaced object inside the corresponding cluster namespace; \"none\" is used for the case of a dedicated provider where isolation is not necessary.")
 	fs.StringVar(&options.ExternalAddress, "external-address", options.ExternalAddress, "The external address for the service provider cluster, including https:// and port. If not specified, service account's hosts are used.")
 	fs.StringVar(&options.ExternalCAFile, "external-ca-file", options.ExternalCAFile, "The external CA file for the service provider cluster. If not specified, service account's CA is used.")
 	fs.StringVar(&options.TLSExternalServerName, "external-server-name", options.TLSExternalServerName, "The external (TLS) server name used by consumers to talk to the service provider cluster. This can be useful to select the right certificate via SNI.")
@@ -113,12 +116,21 @@ func (options *Options) Complete() (*CompletedOptions, error) {
 		return nil, err
 	}
 
-	// normalize the scope
+	// normalize the scope and the isolation
 	if strings.ToLower(options.ConsumerScope) == "namespaced" {
 		options.ConsumerScope = string(kubebindv1alpha1.NamespacedScope)
 	}
 	if strings.ToLower(options.ConsumerScope) == "cluster" {
 		options.ConsumerScope = string(kubebindv1alpha1.ClusterScope)
+	}
+	if strings.EqualFold(options.ClusterScopedIsolation, string(kubebindv1alpha1.IsolationPrefixed)) {
+		options.ClusterScopedIsolation = string(kubebindv1alpha1.IsolationPrefixed)
+	}
+	if strings.EqualFold(options.ClusterScopedIsolation, string(kubebindv1alpha1.IsolationNamespaced)) {
+		options.ClusterScopedIsolation = string(kubebindv1alpha1.IsolationNamespaced)
+	}
+	if strings.EqualFold(options.ClusterScopedIsolation, string(kubebindv1alpha1.IsolationNone)) {
+		options.ClusterScopedIsolation = string(kubebindv1alpha1.IsolationNone)
 	}
 
 	if options.ExternalCAFile != "" && options.ExternalCA != nil {

--- a/contrib/example-backend/options/options.go
+++ b/contrib/example-backend/options/options.go
@@ -123,13 +123,12 @@ func (options *Options) Complete() (*CompletedOptions, error) {
 	if strings.ToLower(options.ConsumerScope) == "cluster" {
 		options.ConsumerScope = string(kubebindv1alpha1.ClusterScope)
 	}
-	if strings.EqualFold(options.ClusterScopedIsolation, string(kubebindv1alpha1.IsolationPrefixed)) {
+	switch strings.ToLower(options.ClusterScopedIsolation) {
+	case "prefixed":
 		options.ClusterScopedIsolation = string(kubebindv1alpha1.IsolationPrefixed)
-	}
-	if strings.EqualFold(options.ClusterScopedIsolation, string(kubebindv1alpha1.IsolationNamespaced)) {
+	case "namespaced":
 		options.ClusterScopedIsolation = string(kubebindv1alpha1.IsolationNamespaced)
-	}
-	if strings.EqualFold(options.ClusterScopedIsolation, string(kubebindv1alpha1.IsolationNone)) {
+	case "none":
 		options.ClusterScopedIsolation = string(kubebindv1alpha1.IsolationNone)
 	}
 

--- a/contrib/example-backend/server.go
+++ b/contrib/example-backend/server.go
@@ -161,6 +161,7 @@ func NewServer(config *Config) (*Server, error) {
 	s.ServiceExportRequest, err = serviceexportrequest.NewController(
 		config.ClientConfig,
 		kubebindv1alpha1.Scope(config.Options.ConsumerScope),
+		kubebindv1alpha1.Isolation(config.Options.ClusterScopedIsolation),
 		config.BindInformers.KubeBind().V1alpha1().APIServiceExportRequests(),
 		config.BindInformers.KubeBind().V1alpha1().APIServiceExports(),
 		config.ApiextensionsInformers.Apiextensions().V1().CustomResourceDefinitions(),

--- a/deploy/crd/kube-bind.io_apiserviceexports.yaml
+++ b/deploy/crd/kube-bind.io_apiserviceexports.yaml
@@ -46,6 +46,11 @@ spec:
           spec:
             description: spec specifies the resource.
             properties:
+              clusterScopedIsolation:
+                description: ClusterScopedIsolation specifies how cluster scoped service
+                  objects are isolated between multiple consumers on the provider
+                  side. It can be "Prefixed", "Namespaced", or "None".
+                type: string
               group:
                 description: "group is the API group of the defined custom resource.
                   Empty string means the core API group. \tThe resources are served

--- a/deploy/crd/kube-bind.io_apiserviceexports.yaml
+++ b/deploy/crd/kube-bind.io_apiserviceexports.yaml
@@ -299,6 +299,8 @@ spec:
               rule: self.scope == "Namespaced" || self.informerScope == "Cluster"
             - message: clusterScopedIsolation must be defined for cluster-scoped resources
               rule: self.scope == "Namespaced" || has(self.clusterScopedIsolation)
+            - message: clusterScopedIsolation is not relevant for namespaced resources
+              rule: self.scope == "Cluster" || !has(self.clusterScopedIsolation)
           status:
             description: status contains reconciliation information for the resource.
             properties:

--- a/deploy/crd/kube-bind.io_apiserviceexports.yaml
+++ b/deploy/crd/kube-bind.io_apiserviceexports.yaml
@@ -50,6 +50,10 @@ spec:
                 description: ClusterScopedIsolation specifies how cluster scoped service
                   objects are isolated between multiple consumers on the provider
                   side. It can be "Prefixed", "Namespaced", or "None".
+                enum:
+                - Prefixed
+                - Namespaced
+                - None
                 type: string
               group:
                 description: "group is the API group of the defined custom resource.
@@ -291,8 +295,10 @@ spec:
             - informerScope
             type: object
             x-kubernetes-validations:
-            - message: informerScope is must be Cluster for cluster-scoped resources
+            - message: informerScope must be Cluster for cluster-scoped resources
               rule: self.scope == "Namespaced" || self.informerScope == "Cluster"
+            - message: clusterScopedIsolation must be defined for cluster-scoped resources
+              rule: self.scope == "Namespaced" || has(self.clusterScopedIsolation)
           status:
             description: status contains reconciliation information for the resource.
             properties:

--- a/pkg/apis/kubebind/v1alpha1/apiserviceexport_types.go
+++ b/pkg/apis/kubebind/v1alpha1/apiserviceexport_types.go
@@ -75,7 +75,8 @@ func (in *APIServiceExport) SetConditions(conditions conditionsapi.Conditions) {
 
 // APIServiceExportSpec defines the desired state of APIServiceExport.
 //
-// +kubebuilder:validation:XValidation:rule=`self.scope == "Namespaced" || self.informerScope == "Cluster"`,message="informerScope is must be Cluster for cluster-scoped resources"
+// +kubebuilder:validation:XValidation:rule=`self.scope == "Namespaced" || self.informerScope == "Cluster"`,message="informerScope must be Cluster for cluster-scoped resources"
+// +kubebuilder:validation:XValidation:rule=`self.scope == "Namespaced" || has(self.clusterScopedIsolation)`,message="clusterScopedIsolation must be defined for cluster-scoped resources"
 type APIServiceExportSpec struct {
 	APIServiceExportCRDSpec `json:",inline"`
 
@@ -93,9 +94,12 @@ type APIServiceExportSpec struct {
 
 	// ClusterScopedIsolation specifies how cluster scoped service objects are isolated between multiple consumers on the provider side.
 	// It can be "Prefixed", "Namespaced", or "None".
-	ClusterScopedIsolation Isolation `json:"clusterScopedIsolation"`
+	ClusterScopedIsolation Isolation `json:"clusterScopedIsolation,omitempty"`
 }
 
+// Isolation is an enum defining the different ways to isolate cluster scoped objects
+//
+// +kubebuilder:validation:Enum=Prefixed;Namespaced;None
 type Isolation string
 
 const (

--- a/pkg/apis/kubebind/v1alpha1/apiserviceexport_types.go
+++ b/pkg/apis/kubebind/v1alpha1/apiserviceexport_types.go
@@ -90,7 +90,24 @@ type APIServiceExportSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="informerScope is immutable"
 	InformerScope Scope `json:"informerScope"`
+
+	// ClusterScopedIsolation specifies how cluster scoped service objects are isolated between multiple consumers on the provider side.
+	// It can be "Prefixed", "Namespaced", or "None".
+	ClusterScopedIsolation Isolation `json:"clusterScopedIsolation"`
 }
+
+type Isolation string
+
+const (
+	// Prepends the name of the cluster namespace to an object's name.
+	IsolationPrefixed Isolation = "Prefixed"
+
+	// Maps a consumer side object into a namespaced object inside the corresponding cluster namespace.
+	IsolationNamespaced Isolation = "Namespaced"
+
+	// Used for the case of a dedicated provider where isolation is not necessary.
+	IsolationNone Isolation = "None"
+)
 
 type APIServiceExportCRDSpec struct {
 	// group is the API group of the defined custom resource. Empty string means the

--- a/pkg/apis/kubebind/v1alpha1/apiserviceexport_types.go
+++ b/pkg/apis/kubebind/v1alpha1/apiserviceexport_types.go
@@ -77,6 +77,7 @@ func (in *APIServiceExport) SetConditions(conditions conditionsapi.Conditions) {
 //
 // +kubebuilder:validation:XValidation:rule=`self.scope == "Namespaced" || self.informerScope == "Cluster"`,message="informerScope must be Cluster for cluster-scoped resources"
 // +kubebuilder:validation:XValidation:rule=`self.scope == "Namespaced" || has(self.clusterScopedIsolation)`,message="clusterScopedIsolation must be defined for cluster-scoped resources"
+// +kubebuilder:validation:XValidation:rule=`self.scope == "Cluster" || !has(self.clusterScopedIsolation)`,message="clusterScopedIsolation is not relevant for namespaced resources"
 type APIServiceExportSpec struct {
 	APIServiceExportCRDSpec `json:",inline"`
 


### PR DESCRIPTION
This PR begins to better address the isolation of the cluster-scoped service objects. As a [follow up](https://github.com/kube-bind/kube-bind/pull/175#issuecomment-1721074910) to a previous PR.

This PR
- adds a `ClusterScopedIsolation` field to the spec of `APIServiceExport`;
- exposes this field as a flag of the example-backend;
- initializes this field when the "kube-bind-example-backend-serviceexportrequest" controller creates an APIServiceExport object.

This PR hasn't added other controllers' reactions to this field, yet.