### PR TITLE
update upload-artifact-retry-action to v0.1.7

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         KREW_GITHUB_TOKEN: ${{ secrets.KREW_GITHUB_TOKEN }}
-    - uses: cytopia/upload-artifact-retry-action@v0.1.2
+    - uses: cytopia/upload-artifact-retry-action@v0.1.7
       if: ${{ always() }}
       with:
         name: binaries


### PR DESCRIPTION
Update `cytopia/upload-artifact-retry-action` to **v0.1.7,** this should be using `actions/download-artifact: v3`.
Yes `actions/download-artifact: v3` is also being deprecated, but using v4 with `cytopia/upload-artifact-retry-action` would require a change there first. I'm hoping this helps at least for now. 

![image](https://github.com/user-attachments/assets/76a6be60-2963-43e9-9975-b9dc721c9753)
