### PR TITLE
Rename dash from group name.

### DIFF
--- a/deploy/crd/kubebind.io_apiservicebindings.yaml
+++ b/deploy/crd/kubebind.io_apiservicebindings.yaml
@@ -4,27 +4,33 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.2
-  name: clusterbindings.kube-bind.io
+  name: apiservicebindings.kubebind.io
 spec:
-  group: kube-bind.io
+  group: kubebind.io
   names:
     categories:
     - kube-bindings
-    kind: ClusterBinding
-    listKind: ClusterBindingList
-    plural: clusterbindings
-    singular: clusterbinding
-  scope: Namespaced
+    kind: APIServiceBinding
+    listKind: APIServiceBindingList
+    plural: apiservicebindings
+    shortNames:
+    - sb
+    singular: apiservicebinding
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.konnectorVersion
-      name: Konnector Version
+    - jsonPath: .status.providerPrettyName
+      name: Provider
       type: string
-    - jsonPath: .status.lastHeartbeatTime
-      name: Last Heartbeat
-      type: date
+    - jsonPath: .metadata.annotations.kube-bind\.io/resources
+      name: Resources
+      priority: 1
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Message
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -33,8 +39,9 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          ClusterBinding represents a bound consumer class. It lives in a service provider cluster
-          and is a singleton named "cluster".
+          APIServiceBinding binds an API service represented by a APIServiceExport
+          in a service provider cluster into a consumer cluster. This object lives in
+          the consumer cluster.
         properties:
           apiVersion:
             description: |-
@@ -54,7 +61,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec represents the data in the newly created ClusterBinding.
+            description: |-
+              spec specifies how an API service from a service provider should be bound in the
+              local consumer cluster.
             properties:
               kubeconfigSecretRef:
                 description: kubeconfigSecretName is the secret ref that contains
@@ -69,38 +78,28 @@ spec:
                     description: Name of the referent.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: Namespace of the referent.
+                    minLength: 1
+                    type: string
                 required:
                 - key
                 - name
+                - namespace
                 type: object
                 x-kubernetes-validations:
                 - message: kubeconfigSecretRef is immutable
                   rule: self == oldSelf
-              providerPrettyName:
-                description: |-
-                  providerPrettyName is the pretty name of the service provider cluster. This
-                  can be shared among different ServiceBindings.
-                minLength: 1
-                type: string
-              serviceProviderSpec:
-                description: |-
-                  serviceProviderSpec contains all the data and information about the service which has been bound to the service
-                  binding request. The service providers decide what they need and what to configure based on what then include in
-                  this field, such as service region, type, tiers, etc...
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
             required:
             - kubeconfigSecretRef
-            - providerPrettyName
             type: object
           status:
-            description: status contains reconciliation information for the service
+            description: status contains reconciliation information for a service
               binding.
             properties:
               conditions:
-                description: |-
-                  conditions is a list of conditions that apply to the ClusterBinding. It is
-                  updated by the konnector and the service provider.
+                description: conditions is a list of conditions that apply to the
+                  APIServiceBinding.
                 items:
                   description: Condition defines an observation of a object operational
                     state.
@@ -144,30 +143,13 @@ spec:
                   - type
                   type: object
                 type: array
-              heartbeatInterval:
+              providerPrettyName:
                 description: |-
-                  heartbeatInterval is the maximal interval between heartbeats that the
-                  konnector promises to send. The service provider can assume that the
-                  konnector is not unhealthy if it does not receive a heartbeat within
-                  this time.
-                type: string
-              konnectorVersion:
-                description: |-
-                  konnectorVersion is the version of the konnector that is running on the
-                  consumer cluster.
-                type: string
-              lastHeartbeatTime:
-                description: lastHeartbeatTime is the last time the konnector updated
-                  the status.
-                format: date-time
+                  providerPrettyName is the pretty name of the service provider cluster. This
+                  can be shared among different APIServiceBindings.
                 type: string
             type: object
-        required:
-        - spec
         type: object
-        x-kubernetes-validations:
-        - message: cluster binding name should be cluster
-          rule: self.metadata.name == "cluster"
     served: true
     storage: true
     subresources:

--- a/deploy/crd/kubebind.io_apiserviceexportrequests.yaml
+++ b/deploy/crd/kubebind.io_apiserviceexportrequests.yaml
@@ -4,33 +4,21 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.2
-  name: apiservicebindings.kube-bind.io
+  name: apiserviceexportrequests.kubebind.io
 spec:
-  group: kube-bind.io
+  group: kubebind.io
   names:
     categories:
     - kube-bindings
-    kind: APIServiceBinding
-    listKind: APIServiceBindingList
-    plural: apiservicebindings
-    shortNames:
-    - sb
-    singular: apiservicebinding
-  scope: Cluster
+    kind: APIServiceExportRequest
+    listKind: APIServiceExportRequestList
+    plural: apiserviceexportrequests
+    singular: apiserviceexportrequest
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.providerPrettyName
-      name: Provider
-      type: string
-    - jsonPath: .metadata.annotations.kube-bind\.io/resources
-      name: Resources
-      priority: 1
-      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Message
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -39,9 +27,9 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          APIServiceBinding binds an API service represented by a APIServiceExport
-          in a service provider cluster into a consumer cluster. This object lives in
-          the consumer cluster.
+          APIServiceExportRequest is represents a request session of kubectl-bind-apiservice.
+
+          The service provider can prune these objects after some time.
         properties:
           apiVersion:
             description: |-
@@ -65,41 +53,60 @@ spec:
               spec specifies how an API service from a service provider should be bound in the
               local consumer cluster.
             properties:
-              kubeconfigSecretRef:
-                description: kubeconfigSecretName is the secret ref that contains
-                  the kubeconfig of the service cluster.
-                properties:
-                  key:
-                    description: The key of the secret to select from.  Must be "kubeconfig".
-                    enum:
-                    - kubeconfig
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: Namespace of the referent.
-                    minLength: 1
-                    type: string
-                required:
-                - key
-                - name
-                - namespace
+              parameters:
+                description: |-
+                  parameters holds service provider specific parameters for this binding
+                  request.
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
                 x-kubernetes-validations:
-                - message: kubeconfigSecretRef is immutable
+                - message: parameters are immutable
+                  rule: self == oldSelf
+              resources:
+                description: resources is a list of resources that should be exported.
+                items:
+                  properties:
+                    group:
+                      default: ""
+                      description: |-
+                        group is the name of an API group.
+                        For core groups this is the empty string '""'.
+                      pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
+                      type: string
+                    resource:
+                      description: |-
+                        resource is the name of the resource.
+                        Note: it is worth noting that you can not ask for permissions for resource provided by a CRD
+                        not provided by an service binding export.
+                      pattern: ^[a-z][-a-z0-9]*[a-z0-9]$
+                      type: string
+                    versions:
+                      description: |-
+                        versions is a list of versions that should be exported. If this is empty
+                        a sensible default is chosen by the service provider.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - resource
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: resources are immutable
                   rule: self == oldSelf
             required:
-            - kubeconfigSecretRef
+            - resources
             type: object
           status:
+            default: {}
             description: status contains reconciliation information for a service
               binding.
             properties:
               conditions:
-                description: conditions is a list of conditions that apply to the
-                  APIServiceBinding.
+                description: |-
+                  conditions is a list of conditions that apply to the ClusterBinding. It is
+                  updated by the konnector and the service provider.
                 items:
                   description: Condition defines an observation of a object operational
                     state.
@@ -143,12 +150,25 @@ spec:
                   - type
                   type: object
                 type: array
-              providerPrettyName:
+              phase:
+                default: Pending
                 description: |-
-                  providerPrettyName is the pretty name of the service provider cluster. This
-                  can be shared among different APIServiceBindings.
+                  phase is the current phase of the binding request. It starts in Pending
+                  and transitions to Succeeded or Failed. See the condition for detailed
+                  information.
+                enum:
+                - Pending
+                - Failed
+                - Succeeded
+                type: string
+              terminalMessage:
+                description: |-
+                  terminalMessage is a human readable message that describes the reason
+                  for the current phase.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/deploy/crd/kubebind.io_apiserviceexports.yaml
+++ b/deploy/crd/kubebind.io_apiserviceexports.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.2
-  name: apiserviceexports.kube-bind.io
+  name: apiserviceexports.kubebind.io
 spec:
-  group: kube-bind.io
+  group: kubebind.io
   names:
     categories:
     - kube-bindings

--- a/deploy/crd/kubebind.io_apiservicenamespaces.yaml
+++ b/deploy/crd/kubebind.io_apiservicenamespaces.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.2
-  name: apiservicenamespaces.kube-bind.io
+  name: apiservicenamespaces.kubebind.io
 spec:
-  group: kube-bind.io
+  group: kubebind.io
   names:
     categories:
     - kube-bindings

--- a/deploy/crd/kubebind.io_clusterbindings.yaml
+++ b/deploy/crd/kubebind.io_clusterbindings.yaml
@@ -1,21 +1,28 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.2
-  name: apiserviceexportrequests.kube-bind.io
+  name: clusterbindings.kubebind.io
 spec:
-  group: kube-bind.io
+  group: kubebind.io
   names:
     categories:
     - kube-bindings
-    kind: APIServiceExportRequest
-    listKind: APIServiceExportRequestList
-    plural: apiserviceexportrequests
-    singular: apiserviceexportrequest
+    kind: ClusterBinding
+    listKind: ClusterBindingList
+    plural: clusterbindings
+    singular: clusterbinding
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.konnectorVersion
+      name: Konnector Version
+      type: string
+    - jsonPath: .status.lastHeartbeatTime
+      name: Last Heartbeat
+      type: date
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -26,9 +33,8 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          APIServiceExportRequest is represents a request session of kubectl-bind-apiservice.
-
-          The service provider can prune these objects after some time.
+          ClusterBinding represents a bound consumer class. It lives in a service provider cluster
+          and is a singleton named "cluster".
         properties:
           apiVersion:
             description: |-
@@ -48,58 +54,47 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              spec specifies how an API service from a service provider should be bound in the
-              local consumer cluster.
+            description: spec represents the data in the newly created ClusterBinding.
             properties:
-              parameters:
+              kubeconfigSecretRef:
+                description: kubeconfigSecretName is the secret ref that contains
+                  the kubeconfig of the service cluster.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be "kubeconfig".
+                    enum:
+                    - kubeconfig
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    minLength: 1
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: kubeconfigSecretRef is immutable
+                  rule: self == oldSelf
+              providerPrettyName:
                 description: |-
-                  parameters holds service provider specific parameters for this binding
-                  request.
+                  providerPrettyName is the pretty name of the service provider cluster. This
+                  can be shared among different ServiceBindings.
+                minLength: 1
+                type: string
+              serviceProviderSpec:
+                description: |-
+                  serviceProviderSpec contains all the data and information about the service which has been bound to the service
+                  binding request. The service providers decide what they need and what to configure based on what then include in
+                  this field, such as service region, type, tiers, etc...
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-                x-kubernetes-validations:
-                - message: parameters are immutable
-                  rule: self == oldSelf
-              resources:
-                description: resources is a list of resources that should be exported.
-                items:
-                  properties:
-                    group:
-                      default: ""
-                      description: |-
-                        group is the name of an API group.
-                        For core groups this is the empty string '""'.
-                      pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
-                      type: string
-                    resource:
-                      description: |-
-                        resource is the name of the resource.
-                        Note: it is worth noting that you can not ask for permissions for resource provided by a CRD
-                        not provided by an service binding export.
-                      pattern: ^[a-z][-a-z0-9]*[a-z0-9]$
-                      type: string
-                    versions:
-                      description: |-
-                        versions is a list of versions that should be exported. If this is empty
-                        a sensible default is chosen by the service provider.
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - resource
-                  type: object
-                minItems: 1
-                type: array
-                x-kubernetes-validations:
-                - message: resources are immutable
-                  rule: self == oldSelf
             required:
-            - resources
+            - kubeconfigSecretRef
+            - providerPrettyName
             type: object
           status:
-            default: {}
-            description: status contains reconciliation information for a service
+            description: status contains reconciliation information for the service
               binding.
             properties:
               conditions:
@@ -149,26 +144,30 @@ spec:
                   - type
                   type: object
                 type: array
-              phase:
-                default: Pending
+              heartbeatInterval:
                 description: |-
-                  phase is the current phase of the binding request. It starts in Pending
-                  and transitions to Succeeded or Failed. See the condition for detailed
-                  information.
-                enum:
-                - Pending
-                - Failed
-                - Succeeded
+                  heartbeatInterval is the maximal interval between heartbeats that the
+                  konnector promises to send. The service provider can assume that the
+                  konnector is not unhealthy if it does not receive a heartbeat within
+                  this time.
                 type: string
-              terminalMessage:
+              konnectorVersion:
                 description: |-
-                  terminalMessage is a human readable message that describes the reason
-                  for the current phase.
+                  konnectorVersion is the version of the konnector that is running on the
+                  consumer cluster.
+                type: string
+              lastHeartbeatTime:
+                description: lastHeartbeatTime is the last time the konnector updated
+                  the status.
+                format: date-time
                 type: string
             type: object
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: cluster binding name should be cluster
+          rule: self.metadata.name == "cluster"
     served: true
     storage: true
     subresources:

--- a/sdk/apis/kubebind/v1alpha1/doc.go
+++ b/sdk/apis/kubebind/v1alpha1/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 defines the v1alpha1 version of the Kube Bind API
 //
-// +groupName=kube-bind.io
+// +groupName=kubebind.io
 // +groupGoName=KubeBind
 // +k8s:deepcopy-gen=package,register
 // +kubebuilder:validation:Optional

--- a/sdk/client/clientset/versioned/typed/kubebind/v1alpha1/kubebind_client.go
+++ b/sdk/client/clientset/versioned/typed/kubebind/v1alpha1/kubebind_client.go
@@ -36,7 +36,7 @@ type KubeBindV1alpha1Interface interface {
 	ClusterBindingsGetter
 }
 
-// KubeBindV1alpha1Client is used to interact with features provided by the kube-bind.io group.
+// KubeBindV1alpha1Client is used to interact with features provided by the kubebind.io group.
 type KubeBindV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/sdk/client/informers/externalversions/generic.go
+++ b/sdk/client/informers/externalversions/generic.go
@@ -53,7 +53,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=kube-bind.io, Version=v1alpha1
+	// Group=kubebind.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("apiservicebindings"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.KubeBind().V1alpha1().APIServiceBindings().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("apiserviceexports"):


### PR DESCRIPTION
Renames group without dash, as client-go + kcp does not like it :/ 