### PR TITLE
Use latest cosign in CI

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -21,7 +21,7 @@ jobs:
         check-latest: true
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'
-    - uses: sigstore/cosign-installer@v2.7.0
+    - uses: sigstore/cosign-installer@latest
     - name: Install ko
       run: go install github.com/google/ko@latest
 


### PR DESCRIPTION
Use the latest signing keys
2.7.0 we use is from Jun 3, 2023

![image](https://github.com/user-attachments/assets/523bf560-91b4-43c2-9f25-1650b6e3eb3d)
