### PR TITLE
Add skip-insecure for calling exports via cli

### DIFF
--- a/pkg/kubectl/bind/plugin/authenticate.go
+++ b/pkg/kubectl/bind/plugin/authenticate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugin
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,8 +36,17 @@ import (
 	kubebindv1alpha1 "github.com/kube-bind/kube-bind/sdk/apis/kubebind/v1alpha1"
 )
 
-func getProvider(url string) (*kubebindv1alpha1.BindingProvider, error) {
-	resp, err := http.Get(url)
+func getProvider(url string, insecure bool) (*kubebindv1alpha1.BindingProvider, error) {
+	client := &http.Client{}
+	if insecure {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecure,
+			},
+		}
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/bind/plugin/bind.go
+++ b/pkg/kubectl/bind/plugin/bind.go
@@ -57,6 +57,9 @@ type BindOptions struct {
 	printer printers.ResourcePrinter
 	DryRun  bool
 
+	// skipInsecure skips the verification of the server's certificate chain and host name.
+	SkipInsecure bool
+
 	// url is the argument accepted by the command. It contains the
 	// reference to where an APIService exists.
 	URL string
@@ -98,6 +101,7 @@ func (b *BindOptions) AddCmdFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&b.SkipKonnector, "skip-konnector", b.SkipKonnector, "Skip the deployment of the konnector")
 	cmd.Flags().BoolVarP(&b.DryRun, "dry-run", "d", b.DryRun, "If true, only print the requests that would be sent to the service provider after authentication, without actually binding.")
+	cmd.Flags().BoolVar(&b.SkipInsecure, "insecure-skip-tls-verify", b.SkipInsecure, "Skip the verification of the server's certificate chain and host name.")
 	cmd.Flags().StringVar(&b.KonnectorImageOverride, "konnector-image", b.KonnectorImageOverride, "The konnector image to use")
 }
 
@@ -150,7 +154,7 @@ func (b *BindOptions) Run(ctx context.Context, urlCh chan<- string) error {
 		return err // should never happen because we test this in Validate()
 	}
 
-	provider, err := getProvider(exportURL.String())
+	provider, err := getProvider(exportURL.String(), b.SkipInsecure)
 	if err != nil {
 		return fmt.Errorf("failed to fetch authentication url %q: %v", exportURL, err)
 	}

--- a/pkg/kubectl/bind/plugin/flags.go
+++ b/pkg/kubectl/bind/plugin/flags.go
@@ -37,6 +37,7 @@ var (
 		"v",
 		"vmodule",
 		"konnector-image",
+		"insecure-skip-tls-verify",
 	)
 
 	// passOnEnvVars are the flags we DO NOT pass to downstream commands like kubectl-bind-apiservice.


### PR DESCRIPTION
Allows skip TLS verification when running in TLS mode with self-signed certificates:

```
kubectl bind https://127.0.0.1:6443/export --insecure-skip-tls-verify      
```