### PR TITLE
fix: restore bind as the root cmd in cli

### DIFF
--- a/cli/cmd/kubectl-bind/cmd/kubectlBind.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind.go
@@ -27,40 +27,25 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
-	"github.com/kube-bind/kube-bind/cli/pkg/help"
 	apiservicecmd "github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind-apiservice/cmd"
 	bindcmd "github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/cmd"
 )
 
 func KubectlBindCommand() *cobra.Command {
-	root := &cobra.Command{
-		Use:   "bind",
-		Short: "kubectl plugin for Kube-Bind.io",
-		Long: help.Doc(`
-			kube-bind is a project that aims to provide better support for 
-			service providers and consumers that reside in distinct Kubernetes clusters.
-
-			For more information, see: https://kube-bind.io
-		`),
-		SilenceUsage:  true,
-		SilenceErrors: true,
-	}
-
-	// setup klog
-	fs := goflags.NewFlagSet("klog", goflags.PanicOnError)
-	klog.InitFlags(fs)
-	root.PersistentFlags().AddGoFlagSet(fs)
-
-	if v := version.Get().String(); len(v) == 0 {
-		root.Version = "<unknown>"
-	} else {
-		root.Version = v
-	}
-
-	bindCmd, err := bindcmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	rootCmd, err := bindcmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v", err)
 		os.Exit(1)
+	}
+	// setup klog
+	fs := goflags.NewFlagSet("klog", goflags.PanicOnError)
+	klog.InitFlags(fs)
+	rootCmd.PersistentFlags().AddGoFlagSet(fs)
+
+	if v := version.Get().String(); len(v) == 0 {
+		rootCmd.Version = "<unknown>"
+	} else {
+		rootCmd.Version = v
 	}
 
 	apiserviceCmd, err := apiservicecmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
@@ -68,8 +53,7 @@ func KubectlBindCommand() *cobra.Command {
 		fmt.Fprintf(os.Stderr, "error: %v", err)
 		os.Exit(1)
 	}
-	bindCmd.AddCommand(apiserviceCmd)
-	root.AddCommand(bindCmd)
+	rootCmd.AddCommand(apiserviceCmd)
 
-	return root
+	return rootCmd
 }

--- a/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2024 The Kube Bind Authors.
+Copyright 2025 The Kube Bind Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	bindcmd "github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/cmd"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubectlBindCommand(t *testing.T) {
+	rootCmd := KubectlBindCommand()
+
+	require.Equal(t, "kubectl-bind", rootCmd.Use, "Unexpected one-line command description")
+	require.Equal(t, "kubectl plugin for Kube-Bind.io, bind different remote types into the current cluster.", rootCmd.Short, "Unexpected short command description")
+	require.Contains(t, rootCmd.Long, "To bind a remote service, use the 'kubectl bind' command.", "Unexpected lond command Long")
+	require.Equal(t, rootCmd.Example, fmt.Sprintf(bindcmd.BindExampleUses, "kubectl"), "Unexpected command Example")
+}
+func TestKubectlBindArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"Valid URL", []string{"https://example.com"}, false},
+		{"Invalid argument", []string{"invalid-arg"}, true},
+		{"Mixed valid and invalid", []string{"https://example.com", "invalid-arg"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := KubectlBindCommand()
+			err := rootCmd.Args(rootCmd, tt.args)
+			if tt.wantErr {
+				require.Error(t, err, "Expected error but got none")
+			} else {
+				require.NoError(t, err, "Unexpected error")
+			}
+		})
+	}
+}

--- a/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kube Bind Authors.
+Copyright 2024 The Kube Bind Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The Kube Bind Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
@@ -17,6 +17,7 @@ func TestKubectlBindCommand(t *testing.T) {
 	require.Contains(t, rootCmd.Long, "To bind a remote service, use the 'kubectl bind' command.", "Unexpected lond command Long")
 	require.Equal(t, rootCmd.Example, fmt.Sprintf(bindcmd.BindExampleUses, "kubectl"), "Unexpected command Example")
 }
+
 func TestKubectlBindArgs(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
+++ b/cli/cmd/kubectl-bind/cmd/kubectlBind_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	bindcmd "github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/cmd"
-
 	"github.com/stretchr/testify/require"
+
+	bindcmd "github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/cmd"
 )
 
 func TestKubectlBindCommand(t *testing.T) {

--- a/cli/pkg/kubectl/bind/cmd/cmd.go
+++ b/cli/pkg/kubectl/bind/cmd/cmd.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	// TODO: add other examples related to permission claim commands.
-	bindExampleUses = `
+	BindExampleUses = `
 	# select a kube-bind.io compatible service from the given URL, e.g. an API service.
 	%[1]s bind https://mangodb.com/exports
 
@@ -63,7 +63,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 		To bind a remote service, use the 'kubectl bind' command.
 		Please check the examples below for more information.
 	`),
-		Example:      fmt.Sprintf(bindExampleUses, "kubectl"),
+		Example:      fmt.Sprintf(BindExampleUses, "kubectl"),
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {

--- a/cli/pkg/kubectl/bind/cmd/cmd.go
+++ b/cli/pkg/kubectl/bind/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	logsv1 "k8s.io/component-base/logs/api/v1"
 
+	"github.com/kube-bind/kube-bind/cli/pkg/help"
 	"github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/plugin"
 )
 
@@ -51,8 +52,17 @@ var (
 func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	opts := plugin.NewBindOptions(streams)
 	cmd := &cobra.Command{
-		Use:          "bind",
-		Short:        "Bind different remote types into the current cluster.",
+		Use:   "kubectl-bind",
+		Short: "kubectl plugin for Kube-Bind.io, bind different remote types into the current cluster.",
+		Long: help.Doc(`
+		kube-bind is a project that aims to provide better support for
+		service providers and consumers that reside in distinct Kubernetes clusters.
+
+		For more information, see: https://kube-bind.io
+
+		To bind a remote service, use the 'kubectl bind' command.
+		Please check the examples below for more information.
+	`),
 		Example:      fmt.Sprintf(bindExampleUses, "kubectl"),
 		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cli/pkg/kubectl/bind/cmd/cmd.go
+++ b/cli/pkg/kubectl/bind/cmd/cmd.go
@@ -23,13 +23,12 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"github.com/kube-bind/kube-bind/cli/pkg/help"
+	"github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/plugin"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/exec"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	logsv1 "k8s.io/component-base/logs/api/v1"
-
-	"github.com/kube-bind/kube-bind/cli/pkg/help"
-	"github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/plugin"
 )
 
 var (
@@ -52,7 +51,7 @@ var (
 func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	opts := plugin.NewBindOptions(streams)
 	cmd := &cobra.Command{
-		Use:   "kubectl-bind",
+		Use:   "bind",
 		Short: "kubectl plugin for Kube-Bind.io, bind different remote types into the current cluster.",
 		Long: help.Doc(`
 		kube-bind is a project that aims to provide better support for

--- a/cli/pkg/kubectl/bind/cmd/cmd.go
+++ b/cli/pkg/kubectl/bind/cmd/cmd.go
@@ -23,12 +23,13 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/kube-bind/kube-bind/cli/pkg/help"
-	"github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/plugin"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/exec"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+
+	"github.com/kube-bind/kube-bind/cli/pkg/help"
+	"github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind/plugin"
 )
 
 var (


### PR DESCRIPTION
## Summary:

This aims to fix the order of commands in `kubectl` plugin, that is currently displayed like this:

```bash
 ./bin/kubectl-bind  
kube-bind is a project that aims to provide better support for service providers and consumers that reside in distinct Kubernetes clusters.

For more information, see: https://kube-bind.io

Usage:
  bind [command]

Available Commands:
  bind        Bind different remote types into the current cluster.
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  ```
  
The current order shows bind bind subcommand.

  ```bash
  ./bin/kubectl-bind bind 
DISCLAIMER: This is a prototype. It will change in incompatible ways at any time.

Bind different remote types into the current cluster.

Usage:
  bind bind [flags]
  bind bind [command]
```
This PR will restore it and plugin help will be shown as:
```bash
kubectl bind
DISCLAIMER: This is a prototype. It will change in incompatible ways at any time.

kube-bind is a project that aims to provide better support for service providers and consumers that reside in distinct Kubernetes clusters.

For more information, see: https://kube-bind.io

To bind a remote service, use the 'kubectl bind' command. Please check the examples below for more information.

Usage:
  kubectl-bind [flags]
  kubectl-bind [command]

Examples:

        # select a kube-bind.io compatible service from the given URL, e.g. an API service.
        kubectl bind https://mangodb.com/exports

        # authenticate and configure the services to bind, but don't actually bind them.
        kubectl bind https://mangodb.com/exports --dry-run -o yaml > apiservice-export-requests.yaml

        # bind to a remote API service as configured above and actually bind to it, e.g. in GitOps automation.
        kubectl bind apiservice --remote-kubeconfig name -f apiservice-binding-requests.yaml

        # bind to a remote API service via a request manifest from a https URL.
        kubectl bind apiservice --remote-kubeconfig name https://some-url.com/apiservice-export-requests.yaml


Available Commands:
  apiservice  Bind to a remote API service
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  ```