### PR TITLE
WIP - remove "" battery from kcp bootraping

### DIFF
--- a/kcp/bootstrap/server.go
+++ b/kcp/bootstrap/server.go
@@ -40,7 +40,7 @@ func NewServer(ctx context.Context, config *Config) (*Server, error) {
 }
 
 func (s *Server) Start(ctx context.Context) error {
-	fakeBatteries := sets.New("")
+	fakeBatteries := sets.New[string]()
 	logger := klog.FromContext(ctx)
 
 	if err := bootstrapconfig.Bootstrap(


### PR DESCRIPTION
## Summary
There is no battery with an empty name in kcp and IMHO this is misleading to use a map with a pseudo element, instead of just an empty map.

## What Type of PR Is This?
/kind cleanup

## Related Issue(s)
Fixes #287

## Release Notes
```release-note
NONE
```
