### PR TITLE
Update SECURITY.md to use GitHub for security issue reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,18 @@
 # Security Process for kube-bind
 
-TBD
+## Reporting a Vulnerability
+
+kube-bind uses GitHub to allow submission of private security reports. Please report any security finding via
+[this link](https://github.com/kube-bind/kube-bind/security/advisories/new).
+Maintainers will triage your report as soon as possible and get in touch with you via your report in case they have more questions.
+
+As a security researcher, please report vulnerabilities to kube-bind in a [coordinated vulnerability disclosure (CVD)](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.html)
+fashion.
+
+In return, maintainers pledge to engage in good faith and collaborate with security researchers to address and publish vulnerabilities found in kube-bind as soon as possible. We will not pursue or support legal action for good‑faith security research that adheres to this policy and avoids privacy violations, data exfiltration, or service disruption.
+
+Please understand that the maintainers also do not accept results of dependency scanners without proof that the detected CVE / vulnerability can be used against kube-bind.
+
+## Security Advisories
+
+Advisories are managed through GitHub Security Advisories. Where applicable, we request CVE IDs via GitHub’s CNA during the advisory process and credit reporters upon release. Please visit [Security Advisories](https://github.com/kube-bind/kube-bind/security/advisories) to review security bulletins published by the maintainers.


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

I would like to propose using GitHub issue reporting for handling security vulnerability disclosure. We will be able to both manage our own disclosures and accept security reports through GitHub, which will also allow us to request CVEs when necessary.

## What Type of PR Is This?

/kind documentation

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced placeholder with a full Security Policy: GitHub-based vulnerability reporting workflow with triage expectations and link to advisories submission.
  * Added coordinated vulnerability disclosure guidance and commitment to good‑faith collaboration (no legal action for compliant research that avoids privacy/data/service harm).
  * Require proof of practical impact for dependency scanner findings.
  * Clarified that advisories are managed via GitHub Security Advisories; CVE requests and reporter crediting described.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->