### PR TITLE
Makefile things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,11 +245,6 @@ COUNT ?= 1
 NPROC ?= $$(( $(shell nproc) / 2 ))
 E2E_PARALLELISM ?= $$(( $(NPROC) > 1 ? $(NPROC) : 1))
 
-dex:
-		git clone https://github.com/dexidp/dex.git
-dex/bin/dex: dex
-		(cd dex; make)
-
 $(DEX):
 	mkdir -p $(TOOLS_DIR)
 	git clone --branch $(DEX_VER) --depth 1 https://github.com/dexidp/dex $(TOOLS_DIR)/dex-clone-$(DEX_VER) || true


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Some minor improvements for the makefile

1. Parallelism is now set based on number of cores/2 rather forced to 1
2. Add run-dex recipe and use run-dex and run-kcp in test-e2e
3. Symlink dex and kcp in hack/tools - this allows e.g. the kcp sdk/testing to use the kcp binary in there for test servers

## What Type of PR Is This?

/kind cleanup

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
