### PR TITLE
Revert deps dump

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -35,10 +35,10 @@ import (
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 
 	kuberesources "github.com/kube-bind/kube-bind/backend/kubernetes/resources"
 	"github.com/kube-bind/kube-bind/backend/options"
-	"github.com/kube-bind/kube-bind/backend/provider"
 	kubebindv1alpha1 "github.com/kube-bind/kube-bind/sdk/apis/kubebind/v1alpha1"
 	kubebindv1alpha2 "github.com/kube-bind/kube-bind/sdk/apis/kubebind/v1alpha2"
 )
@@ -46,7 +46,7 @@ import (
 type Config struct {
 	Options *options.CompletedOptions
 
-	Provider                 provider.MultiClusterProvider
+	Provider                 multicluster.Provider
 	ExternalAddressGenerator kuberesources.ExternalAddreesGeneratorFunc
 	Manager                  mcmanager.Manager
 	Scheme                   *runtime.Scheme

--- a/backend/provider/provider.go
+++ b/backend/provider/provider.go
@@ -15,11 +15,3 @@ limitations under the License.
 */
 
 package provider
-
-import "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
-
-// MultiClusterProvider is an interface that combines multicluster.Provider and multicluster.ProviderRunnable.
-type MultiClusterProvider interface {
-	multicluster.Provider
-	multicluster.ProviderRunnable
-}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 replace (
 	github.com/google/cel-go => github.com/google/cel-go v0.22.0
 	github.com/kcp-dev/apimachinery/v2 => github.com/kcp-dev/apimachinery/v2 v2.0.1-0.20250728122101-adbf20db3e51
-	github.com/kcp-dev/multicluster-provider => github.com/mjudeikis/kcp-multicluster-provider v0.0.0-20250924135430-a1b0eea41697
+	github.com/kcp-dev/multicluster-provider => github.com/mjudeikis/kcp-multicluster-provider v0.0.0-20250818102159-3d31cbb06ebe
 	k8s.io/api => k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.0
 	k8s.io/apimachinery => k8s.io/apimachinery v0.33.0
@@ -24,7 +24,7 @@ replace (
 	k8s.io/component-base => k8s.io/component-base v0.33.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.21.0
 	//sigs.k8s.io/multicluster-runtime => sigs.k8s.io/multicluster-runtime v0.20.4-alpha.7
-	sigs.k8s.io/multicluster-runtime => github.com/mjudeikis/sigs-multicluster-runtime v0.0.0-20250924135253-419f38e2cced
+	sigs.k8s.io/multicluster-runtime => github.com/mjudeikis/sigs-multicluster-runtime v0.0.0-20250818101434-d8ebc45e169b
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -163,10 +163,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdp/qrterminal/v3 v3.2.0 h1:qteQMXO3oyTK4IHwj2mWsKYYRBOp1Pj2WRYFYYNTCdk=
 github.com/mdp/qrterminal/v3 v3.2.0/go.mod h1:XGGuua4Lefrl7TLEsSONiD+UEjQXJZ4mPzF+gWYIJkk=
-github.com/mjudeikis/kcp-multicluster-provider v0.0.0-20250924135430-a1b0eea41697 h1:JD5KZQ2Wgd1YpMkHZHjWnY1vN7Tum2mS21hFalsluTs=
-github.com/mjudeikis/kcp-multicluster-provider v0.0.0-20250924135430-a1b0eea41697/go.mod h1:Z+mhTzOrNasK0Tcb3dryZAm8Qen16X8ExCGlHAe21cw=
-github.com/mjudeikis/sigs-multicluster-runtime v0.0.0-20250924135253-419f38e2cced h1:QQeHizakPBEsphr3NomO+SPRIU8V3IgpSGr/V4Ttuy0=
-github.com/mjudeikis/sigs-multicluster-runtime v0.0.0-20250924135253-419f38e2cced/go.mod h1:CpBzLMLQKdm+UCchd2FiGPiDdCxM5dgCCPKuaQ6Fsv0=
+github.com/mjudeikis/kcp-multicluster-provider v0.0.0-20250818102159-3d31cbb06ebe h1:rSMxNO43EhRCu49OxJrcueT3x8QJdtDgg9QNsjj8UCI=
+github.com/mjudeikis/kcp-multicluster-provider v0.0.0-20250818102159-3d31cbb06ebe/go.mod h1:AQbVcrm76lpSFQ/8Gkbf0ev1eTqbk+dynDw6IW8oprA=
+github.com/mjudeikis/sigs-multicluster-runtime v0.0.0-20250818101434-d8ebc45e169b h1:rWXhKkj+BFmR08VYCRVW1/5n+PgKAzcrueYVPjN3K/g=
+github.com/mjudeikis/sigs-multicluster-runtime v0.0.0-20250818101434-d8ebc45e169b/go.mod h1:CpBzLMLQKdm+UCchd2FiGPiDdCxM5dgCCPKuaQ6Fsv0=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

controller-runtime runner is not yet working. Clusters are not engaged as provider is not auto-started

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Revert multicluster-runtime bump.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Refactor
  - Streamlined backend configuration by adopting a unified multicluster provider interface.
  - Removed redundant internal abstractions to simplify provider integration and initialization.

- Chores
  - Updated multicluster-related dependencies to newer versions for compatibility and maintenance.
  - General codebase cleanup aligned with the new provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->