### PR TITLE
Fix missing kcp=>contrib/kcp renames

### DIFF
--- a/contrib/kcp/bootstrap/config.go
+++ b/contrib/kcp/bootstrap/config.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/kube-bind/kube-bind/kcp/bootstrap/options"
+	"github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/options"
 )
 
 type Config struct {

--- a/contrib/kcp/bootstrap/config/core/bootstrap.go
+++ b/contrib/kcp/bootstrap/config/core/bootstrap.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/kube-bind/kube-bind/kcp/bootstrap/config/core/resources"
+	"github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/config/core/resources"
 )
 
 var (

--- a/contrib/kcp/bootstrap/server.go
+++ b/contrib/kcp/bootstrap/server.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
-	bootstrapconfig "github.com/kube-bind/kube-bind/kcp/bootstrap/config/config"
-	bootstrapcore "github.com/kube-bind/kube-bind/kcp/bootstrap/config/core"
-	bootstrapkubebind "github.com/kube-bind/kube-bind/kcp/bootstrap/config/kcp"
+	bootstrapconfig "github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/config/config"
+	bootstrapcore "github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/config/core"
+	bootstrapkubebind "github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/config/kcp"
 )
 
 type Server struct {

--- a/contrib/kcp/cmd/kcp-init/main.go
+++ b/contrib/kcp/cmd/kcp-init/main.go
@@ -26,8 +26,8 @@ import (
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 
-	bootstrap "github.com/kube-bind/kube-bind/kcp/bootstrap"
-	"github.com/kube-bind/kube-bind/kcp/bootstrap/options"
+	bootstrap "github.com/kube-bind/kube-bind/contrib/kcp/bootstrap"
+	"github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/options"
 )
 
 func main() {

--- a/contrib/kcp/deploy/bootstrap.go
+++ b/contrib/kcp/deploy/bootstrap.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
-	"github.com/kube-bind/kube-bind/kcp/bootstrap/config/kcp/resources"
+	"github.com/kube-bind/kube-bind/contrib/kcp/bootstrap/config/kcp/resources"
 )
 
 var (

--- a/contrib/kcp/go.mod
+++ b/contrib/kcp/go.mod
@@ -1,4 +1,4 @@
-module github.com/kube-bind/kube-bind/kcp
+module github.com/kube-bind/kube-bind/contrib/kcp
 
 go 1.24.0
 


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

The modules wasn't actually renamed, leading to other issues

## What Type of PR Is This?

/kind bug

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Reorganized contrib/kcp module under a new path and aligned internal references for consistency.
  * Standardized bootstrap resource imports within the contrib scope.
  * No functional or interface changes; existing workflows and commands behave as before.
  * No user action required; this is a maintenance update improving repository structure and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->