### PR TITLE
Add framework.StartDex and export framework.CreateDexClient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,8 @@ test-e2e: WORK_DIR ?= .
 test-e2e: WHAT ?= ./test/e2e...
 test-e2e: $(KCP) $(DEX) build ## Run e2e tests
 	mkdir .kcp
-	$(MAKE) run-dex 2>&1 & DEX_PID=$$!; \
 	$(MAKE) run-kcp &>.kcp/kcp.log & KCP_PID=$$!; \
-	trap 'kill -TERM $$DEX_PID $$KCP_PID; rm -rf .kcp' TERM INT EXIT && \
+	trap 'kill -TERM $$KCP_PID; rm -rf .kcp' TERM INT EXIT && \
 	echo "Waiting for kcp to be ready (check .kcp/kcp.log)." && while ! KUBECONFIG=.kcp/admin.kubeconfig kubectl get --raw /readyz &>/dev/null; do sleep 1; echo -n "."; done && echo && \
 	KUBECONFIG=$$PWD/.kcp/admin.kubeconfig GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
 

--- a/test/e2e/bind/happy-case_test.go
+++ b/test/e2e/bind/happy-case_test.go
@@ -59,6 +59,8 @@ func testHappyCase(t *testing.T, resourceScope apiextensionsv1.ResourceScope, in
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	framework.StartDex(t)
+
 	t.Logf("Creating provider workspace")
 	providerConfig, providerKubeconfig := framework.NewWorkspace(t, framework.ClientConfig(t), framework.WithGenerateName("test-happy-case-provider"))
 

--- a/test/e2e/framework/dex.go
+++ b/test/e2e/framework/dex.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025 The Kube Bind Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	dexapi "github.com/dexidp/dex/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	grpcinsecure "google.golang.org/grpc/credentials/insecure"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var dexOnce sync.Once
+
+func StartDex(t testing.TB) {
+	t.Helper()
+
+	dexOnce.Do(func() {
+		dexConfig := os.Getenv("DEX_CONFIG")
+		if dexConfig == "" {
+			dexConfig = filepath.Clean(filepath.Join(WorkDir, "..", "hack", "dex-config-dev.yaml"))
+		}
+
+		t.Logf("Starting dex with config %q", dexConfig)
+
+		dexCmd := exec.Command(
+			"dex",
+			"serve",
+			dexConfig,
+		)
+
+		// Ensures that dex is killed when the process ends.
+		dexCmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGKILL,
+			Setpgid:   true,
+			Pgid:      0,
+		}
+
+		require.NoError(t, dexCmd.Start())
+	})
+
+	t.Log("Wait for Dex to be ready")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://127.0.0.1:5556/dex/.well-known/openid-configuration", nil)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+	t.Log("Dex is ready")
+}
+
+func CreateDexClient(t testing.TB, addr net.Addr) {
+	t.Helper()
+
+	_, port, err := net.SplitHostPort(addr.String())
+	require.NoError(t, err)
+	conn, err := grpc.NewClient("127.0.0.1:5557", grpc.WithTransportCredentials(grpcinsecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+	client := dexapi.NewDexClient(conn)
+
+	_, err = client.CreateClient(t.Context(), &dexapi.CreateClientReq{
+		Client: &dexapi.Client{
+			Id:           "kube-bind-" + port,
+			Secret:       "ZXhhbXBsZS1hcHAtc2VjcmV0",
+			RedirectUris: []string{fmt.Sprintf("http://%s/callback", addr)},
+			Public:       true,
+			Name:         "kube-bind on port " + port,
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithDeadline(context.Background(), metav1.Now().Add(10*time.Second))
+		defer cancel()
+		conn, err := grpc.NewClient("127.0.0.1:5557", grpc.WithTransportCredentials(grpcinsecure.NewCredentials()))
+		require.NoError(t, err)
+		_, err = dexapi.NewDexClient(conn).DeleteClient(ctx, &dexapi.DeleteClientReq{Id: "kube-bind-" + port})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Add `framework.StartDex` for tests to ensure dex is running.

## What Type of PR Is This?

/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Centralized auth-service startup and readiness checks to improve end-to-end stability.
  - Automated registration and cleanup of test auth clients to reduce flakiness.
  - Simplified test setup by removing redundant helpers and unused imports.

- Chores
  - Removed auth-service process management from the test build target, delegating lifecycle to the test framework.
  - Reduced parallel startup complexity for faster, more reliable test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->