### PR TITLE
fix: prevent dry-run from creating resources on consumer cluster

### DIFF
--- a/cli/pkg/kubectl/base/dryrun.go
+++ b/cli/pkg/kubectl/base/dryrun.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Kube Bind Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import "time"
+
+// DryRunAssets represents the saved assets from a dry-run
+type DryRunAssets struct {
+	SessionID    string    `json:"sessionID"`
+	UserID       string    `json:"userID"`
+	ServerURL    string    `json:"serverURL"`
+	ClusterID    string    `json:"clusterID,omitempty"`
+	CreatedAt    time.Time `json:"createdAt"`
+	Kubeconfig   string    `json:"kubeconfig"`
+	RequestFiles []string  `json:"requestFiles"`
+}

--- a/cli/pkg/kubectl/bind/cmd/cmd.go
+++ b/cli/pkg/kubectl/bind/cmd/cmd.go
@@ -44,8 +44,11 @@ var (
 	# Bind specific template (CLI mode)
 	%[1]s bind apiservice --name my-api --template-name database-service
 
-	# View template details without binding
+	# View template details without binding. This also saves assets locally for later use.
 	%[1]s bind apiservice --name my-api --template-name database-service --dry-run
+	
+	# Apply bindings from a previous dry-run session
+	%[1]s bind apiservice --from-dry-run <session-id>
 	`
 )
 

--- a/contrib/kcp/README.md
+++ b/contrib/kcp/README.md
@@ -118,13 +118,9 @@ kubectl ws create consumer --enter
 ./bin/kubectl-bind login http://127.0.0.1:8080 --cluster 2ocmmccjkme8bof4 
 ./bin/kubectl-bind --dry-run -o yaml > apiserviceexport.yaml
 
-# Extract secret for binding process. Note that secret name is not the same as output from command above. Check secret
-# name by running `kubectl get secret -n kube-bind`
-kubectl get secrets -n kube-bind -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > remote.kubeconfig
-
-namespace=$(yq '.contexts[0].context.namespace' remote.kubeconfig)
-
-./bin/kubectl-bind apiservice -v 6 --remote-kubeconfig remote.kubeconfig -f apiserviceexport.yaml --skip-konnector --remote-namespace "$namespace"
+# The dry-run saves assets locally and does not create any resources on the consumer cluster.
+# Use --from-dry-run with the session ID (printed at the end of dry-run output, or find it in ~/.kube-bind/dry-run/)
+./bin/kubectl-bind apiservice --from-dry-run <session-id> --skip-konnector
 ```
 
 This will keep running, so switch to a new terminal.

--- a/docs/content/developers/dev-environments.md
+++ b/docs/content/developers/dev-environments.md
@@ -128,13 +128,9 @@ All the instructions assume you have already cloned the kube-bind repository and
     ./bin/kubectl-bind login http://127.0.0.1:8080 --cluster 2myqz7lt9i0u5kzb
     ./bin/kubectl-bind --dry-run -o yaml > apiserviceexport.yaml
 
-    # Extract secret for binding process. Note that secret name is not the same as output from command above. Check secret
-    # name by running `kubectl get secret -n kube-bind`
-    kubectl get secrets -n kube-bind -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > remote.kubeconfig
-
-    namespace=$(yq '.contexts[0].context.namespace' remote.kubeconfig)
-
-    ./bin/kubectl-bind apiservice -v 6 --remote-kubeconfig remote.kubeconfig -f apiserviceexport.yaml --skip-konnector --remote-namespace "$namespace"
+    # The dry-run saves assets locally and does not create any resources on the consumer cluster.
+    # Use --from-dry-run with the session ID (printed at the end of dry-run output, or find it in ~/.kube-bind/dry-run/)
+    ./bin/kubectl-bind apiservice --from-dry-run <session-id> --skip-konnector
     ```
 
     This will keep running, so switch to a new terminal.

--- a/test/e2e/bind/dry-run_test.go
+++ b/test/e2e/bind/dry-run_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2025 The Kube Bind Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bind
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	bindapiservice "github.com/kube-bind/kube-bind/cli/pkg/kubectl/bind-apiservice/plugin"
+	examples "github.com/kube-bind/kube-bind/deploy/examples"
+	kubebindv1alpha2 "github.com/kube-bind/kube-bind/sdk/apis/kubebind/v1alpha2"
+	"github.com/kube-bind/kube-bind/test/e2e/framework"
+)
+
+func TestDryRunClusterScoped(t *testing.T) {
+	t.Parallel()
+	testDryRun(t, "cc", apiextensionsv1.ClusterScoped, kubebindv1alpha2.ClusterScope)
+}
+
+func testDryRun(
+	t *testing.T,
+	name string,
+	resourceScope apiextensionsv1.ResourceScope,
+	informerScope kubebindv1alpha2.InformerScope,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	framework.StartDex(t)
+
+	suffix := framework.RandomString(4)
+
+	t.Logf("Creating provider workspace")
+	providerConfig, providerKubeconfig := framework.NewWorkspace(t, framework.ClientConfig(t), framework.WithName("%s-provider-%s", name, suffix))
+
+	t.Logf("Installing kubebind CRDs")
+	framework.InstallKubebindCRDs(t, providerConfig)
+
+	t.Logf("Starting backend with random port")
+	addr, _ := framework.StartBackend(t, "--kubeconfig="+providerKubeconfig, "--listen-address=:0", "--consumer-scope="+string(informerScope))
+
+	t.Logf("Creating CRD on provider side")
+	examples.Bootstrap(t, framework.DiscoveryClient(t, providerConfig), framework.DynamicClient(t, providerConfig), nil)
+
+	t.Logf("Creating consumer workspace and starting konnector")
+	consumerConfig, consumerKubeconfig := framework.NewWorkspace(t, framework.ClientConfig(t), framework.WithName("%s-consumer-%s", name, suffix))
+	framework.StartKonnector(t, consumerConfig, "--kubeconfig="+consumerKubeconfig)
+
+	serviceGVR := schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "cowboys"}
+	if resourceScope == apiextensionsv1.ClusterScoped {
+		serviceGVR = schema.GroupVersionResource{Group: "wildwest.dev", Version: "v1alpha1", Resource: "sheriffs"}
+	}
+	templateRef := "cowboys"
+	if resourceScope == apiextensionsv1.ClusterScoped {
+		templateRef = "sheriffs"
+	}
+
+	consumerBindClient := framework.BindClient(t, consumerConfig)
+
+	// Create a temporary directory for dry-run assets
+	tempHomeDir := t.TempDir()
+	originalHomeDir := os.Getenv("HOME")
+	os.Setenv("HOME", tempHomeDir)
+	t.Cleanup(func() {
+		if originalHomeDir != "" {
+			os.Setenv("HOME", originalHomeDir)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	})
+
+	kubeBindConfig := filepath.Join(framework.WorkDir, fmt.Sprintf("kube-bind-config-%s.yaml", suffix))
+
+	var bindResponse *kubebindv1alpha2.BindingResourceResponse
+	var sessionID string
+	for _, tc := range []struct {
+		name string
+		step func(t *testing.T)
+	}{
+		{
+			name: "Login to provider",
+			step: func(t *testing.T) {
+				iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+				authURLDryRunCh := make(chan string, 1)
+				go framework.SimulateBrowser(t, authURLDryRunCh)
+				framework.Login(t, iostreams, authURLDryRunCh, kubeBindConfig, fmt.Sprintf("http://%s/api/exports", addr.String()), "")
+			},
+		},
+		{
+			name: "Get bind APIServiceExportRequest from server",
+			step: func(t *testing.T) {
+				c := framework.GetKubeBindRestClient(t, kubeBindConfig)
+				var err error
+				bindResponse, err = c.Bind(ctx, &kubebindv1alpha2.BindableResourcesRequest{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-binding",
+					},
+					TemplateRef: kubebindv1alpha2.APIServiceExportTemplateRef{
+						Name: templateRef,
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, bindResponse)
+				require.NotNil(t, bindResponse.Authentication.OAuth2CodeGrant)
+				sessionID = bindResponse.Authentication.OAuth2CodeGrant.SessionID
+				require.NotEmpty(t, sessionID)
+			},
+		},
+		{
+			name: "Run dry-run with template - verify no consumer cluster resources created",
+			step: func(t *testing.T) {
+				iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+				opts := bindapiservice.NewBindAPIServiceOptions(iostreams)
+				opts.ConfigFile = kubeBindConfig
+				opts.Kubeconfig = consumerKubeconfig
+				opts.Template = templateRef
+				opts.DryRun = true
+				opts.SkipKonnector = true
+
+				err := opts.Complete(nil)
+				require.NoError(t, err)
+				err = opts.Validate()
+				require.NoError(t, err)
+
+				bindings, err := consumerBindClient.KubeBindV1alpha2().APIServiceBindings().List(ctx, metav1.ListOptions{})
+				require.NoError(t, err)
+				initialBindingCount := len(bindings.Items)
+
+				crdClient := framework.ApiextensionsClient(t, consumerConfig).ApiextensionsV1().CustomResourceDefinitions()
+				_, err = crdClient.Get(ctx, serviceGVR.Resource+"."+serviceGVR.Group, metav1.GetOptions{})
+				require.True(t, errors.IsNotFound(err), "CRD should not exist before dry-run")
+
+				err = opts.Run(ctx)
+				require.NoError(t, err)
+
+				bindings, err = consumerBindClient.KubeBindV1alpha2().APIServiceBindings().List(ctx, metav1.ListOptions{})
+				require.NoError(t, err)
+				require.Equal(t, initialBindingCount, len(bindings.Items), "No bindings should be created during dry-run")
+
+				_, err = crdClient.Get(ctx, serviceGVR.Resource+"."+serviceGVR.Group, metav1.GetOptions{})
+				require.True(t, errors.IsNotFound(err), "CRD should not be created during dry-run")
+			},
+		},
+		{
+			name: "Apply from dry-run assets - verify bindings are created",
+			step: func(t *testing.T) {
+				iostreams, _, _, _ := genericclioptions.NewTestIOStreams()
+				opts := bindapiservice.NewBindAPIServiceOptions(iostreams)
+				opts.ConfigFile = kubeBindConfig
+				opts.Kubeconfig = consumerKubeconfig
+				opts.FromDryRun = sessionID
+				opts.SkipKonnector = true
+
+				err := opts.Complete(nil)
+				require.NoError(t, err)
+				err = opts.Validate()
+				require.NoError(t, err)
+
+				err = opts.Run(ctx)
+				require.NoError(t, err)
+
+				t.Logf("Waiting for %s CRD to be created on consumer side", serviceGVR.Resource)
+				crdClient := framework.ApiextensionsClient(t, consumerConfig).ApiextensionsV1().CustomResourceDefinitions()
+				require.Eventually(t, func() bool {
+					_, err := crdClient.Get(ctx, serviceGVR.Resource+"."+serviceGVR.Group, metav1.GetOptions{})
+					return err == nil
+				}, wait.ForeverTestTimeout, time.Millisecond*100, "waiting for %s CRD to be created on consumer side", serviceGVR.Resource)
+
+				bindings, err := consumerBindClient.KubeBindV1alpha2().APIServiceBindings().List(ctx, metav1.ListOptions{})
+				require.NoError(t, err)
+				require.Greater(t, len(bindings.Items), 0, "At least one binding should be created")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.step(t)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
Change fixes dry-run flag to ensure that binding assets are only saved locally without accessing 
the consumer cluster, and adds `--from-dry-run` flag to apply saved dry-run sessions later.
```
<img width="971" height="786" alt="image" src="https://github.com/user-attachments/assets/b315cb3e-3ba5-43b4-891e-4ea6c584f6e0" />

```
making use of the assets
```
<img width="971" height="283" alt="image" src="https://github.com/user-attachments/assets/f7f18ad5-4379-4cbf-a852-ed0de2747fea" />

```
running apiservice dry-run for template
```

<img width="1716" height="1152" alt="image" src="https://github.com/user-attachments/assets/6fcbf9fb-1429-4f31-90ef-a5562eefd62d" />


## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [365](https://github.com/kube-bind/kube-bind/issues/365)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added dry-run mode that saves assets locally without consumer cluster access, and `--from-dry-run` flag to apply saved dry-run sessions.
```
