### PR TITLE
Add tag for 0.0.0-sha

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -62,6 +62,7 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/konnector:latest
           ghcr.io/${{ github.repository_owner }}/konnector:${{ github.sha }}
+          ghcr.io/${{ github.repository_owner }}/konnector:0.0.0-${{ github.sha }}
           ghcr.io/${{ github.repository_owner }}/konnector:${{ github.ref_name }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
@@ -100,6 +101,7 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository_owner }}/backend:latest
           ghcr.io/${{ github.repository_owner }}/backend:${{ github.sha }}
+          ghcr.io/${{ github.repository_owner }}/backend:0.0.0-${{ github.sha }}
           ghcr.io/${{ github.repository_owner }}/backend:${{ github.ref_name }}
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

When installing from commit:
```bash
VERSION=0.0.0-b6340bfd0a317614357c56799f5aec2ffe96c6e6                                                                                                                              10:06:09
~/go/src/github.com/kube-bind/kube-bind @b6340bfd ❯ code .                                                                                                                                                                              10:06:34
~/go/src/github.com/kube-bind/kube-bind @b6340bfd ❯ helm upgrade --install \                                                                                                                                                            10:06:49
       --namespace kube-bind \
       --create-namespace \
       kube-bind oci://ghcr.io/kube-bind/charts/backend --version ${VERSION}
```

`0.0.0-sha` is syntax OCI helm images are using. This adds same tag to images so we dont need to override images tags and "it just works" 
/kind feature

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
add 0.0.0-git-sha tag to images 
```
