### PR TITLE
do not pollute global kubeconfig when creating a dev setup

### DIFF
--- a/cli/pkg/kubectl/base/kubeconfig.go
+++ b/cli/pkg/kubectl/base/kubeconfig.go
@@ -19,6 +19,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -146,4 +147,14 @@ func LoadRestConfigFromString(kubeconfig string) (*rest.Config, error) {
 		return nil, fmt.Errorf("failed to build config from kubeconfig: %w", err)
 	}
 	return config, nil
+}
+
+// LoadRestConfigFromFile loads a kubeconfig file and returns a rest.Config
+func LoadRestConfigFromFile(kubeconfig string) (*rest.Config, error) {
+	content, err := os.ReadFile(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	return LoadRestConfigFromString(string(content))
 }


### PR DESCRIPTION
## Summary
The `k bind dev create` command already spits out 2 kubeconfig files. It is unnecessary for it to _also_ modify my fallback system-wide kubeconfig. This happens by "accident" when running `kind create cluster` without an explicit kubeconfig path.

This PR changes the call to kind and explicitly configures the desired kubeconfig path, so kind will not touch my ~/.kube/config anymore (me personally, I kind of rely on it being empty and defaulting to localhost:8080 for some other automation; I also hate it when I run such a command with a KUBECONFIG variable set and accidentally overwrite it with a kind kubeconfig).

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
NONE
```
