### PR TITLE
fix log line in serviceexport controller

### DIFF
--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
@@ -322,7 +322,7 @@ func (c *controller) enqueueServiceNamespace(logger klog.Logger, obj any) {
 			runtime.HandleError(err)
 			continue
 		}
-		logger.V(2).Info("queueing Unstructured", "key", key, "reason", "APIServiceNamespace", "ServiceNamespaceKey", key)
+		logger.V(2).Info("queueing Unstructured", "key", key, "reason", "APIServiceNamespace", "ServiceNamespaceKey", snKey)
 		c.queue.Add(key)
 	}
 }

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -300,7 +300,7 @@ func (c *controller) enqueueServiceNamespace(logger klog.Logger, obj any) {
 			runtime.HandleError(err)
 			continue
 		}
-		logger.V(2).Info("queueing Unstructured", "key", key, "reason", "APIServiceNamespace", "ServiceNamespaceKey", key)
+		logger.V(2).Info("queueing Unstructured", "key", key, "reason", "APIServiceNamespace", "ServiceNamespaceKey", snKey)
 		c.queue.Add(key)
 	}
 }


### PR DESCRIPTION
## Summary
We used the wrong variable here.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
Fix log context key `ServiceNamespaceKey` pointing to the wrong object.
```
