### PR TITLE
fix(docs): Add synopsis for bind apiservice

### DIFF
--- a/cli/pkg/kubectl/bind-apiservice/cmd/cmd.go
+++ b/cli/pkg/kubectl/bind-apiservice/cmd/cmd.go
@@ -44,9 +44,22 @@ var (
 func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	opts := plugin.NewBindAPIServiceOptions(streams)
 	cmd := &cobra.Command{
-		Use:          "apiservice https://<url-to-a-APIServiceExportRequest>|-f <file-to-a-APIBindingRequest>",
-		Short:        "Bind to a remote API service",
-		Example:      help.Examplesf(bindAPIServiceExampleUses, "kubectl bind"),
+		Use:   "apiservice https://<url-to-a-APIServiceExportRequest>|-f <file-to-a-APIBindingRequest>",
+		Short: "Bind to a remote API service",
+		Long: help.Doc(`
+		Bind to a remote API service by creating an APIServiceExportRequest.
+
+		This command allows you to bind remote services into your cluster by either:
+
+		- Providing a URL to an APIServiceExportRequest resource
+		- Providing a file containing an APIServiceExportRequest manifest
+		- Using a template name to interactively create the binding
+
+		The command will authenticate with the remote service provider, create the necessary
+		APIServiceExportRequest, and deploy a konnector to establish the connection between
+		your cluster and the remote service.
+		`),
+		Example:      fmt.Sprintf(bindAPIServiceExampleUses, "kubectl bind"),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := logsv1.ValidateAndApply(opts.Logs, nil); err != nil {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary
```
Change adds the description for the "bind apiservice" command, which was missing a synopsis and a detailed explanation.
```

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes [391](https://github.com/kube-bind/kube-bind/issues/391)

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Added synopsis for bind apiservice command.
```
