### PR TITLE
fix missing livereload in local-docs makefile target

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,6 @@ mkdocs-macros-plugin==1.0.5
 mkdocs-material==9.5.49
 mkdocs-material-extensions==1.3.1
 mkdocs-static-i18n==1.2.2
+
+# https://github.com/mkdocs/mkdocs/issues/4032
+click<=8.2.1


### PR DESCRIPTION
## Summary
I thought it was me, but no, apparently an upstream issue in mkdocs/clicks/something is accidentally disabling the default livereload functionality: https://github.com/mkdocs/mkdocs/issues/4032

The suggested workaround is to pin one of the dependencies to an older version.

## What Type of PR Is This?
/kind bug

## Release Notes
```release-note
NONE
```
