### PR TITLE
add support for choosing kind network in dev mode

### DIFF
--- a/cli/pkg/kubectl/dev/cmd/cmd.go
+++ b/cli/pkg/kubectl/dev/cmd/cmd.go
@@ -52,7 +52,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 		Short: "Manage development environment for kube-bind",
 		Long: help.Doc(`
 		Manage a development environment for kube-bind using kind clusters.
-		
+
 		This command provides subcommands to initialize and manage kind clusters
 		configured for kube-bind development.
 	`),
@@ -90,13 +90,13 @@ func newInitCommand(streams genericclioptions.IOStreams) (*cobra.Command, error)
 		Short: "Create development environment with kind cluster and kube-bind backend",
 		Long: help.Doc(`
 		Create a complete development environment for kube-bind using kind clusters.
-		
+
 		This command will:
 		- Create a kind cluster configured for kube-bind development
 		- Add kube-bind.dev.local to /etc/hosts (with sudo prompts if needed)
 		- Install kube-bind backend helm chart (default: OCI chart from ghcr.io)
 		- Configure necessary port mappings (8443, 15021)
-		
+
 		The backend chart can be sourced from:
 		- OCI registry (default): oci://ghcr.io/kube-bind/charts/backend
 		- Local filesystem: --chart-path ./deploy/charts/backend
@@ -133,7 +133,7 @@ func newDeleteCommand(streams genericclioptions.IOStreams) (*cobra.Command, erro
 		Short: "Delete development environment",
 		Long: help.Doc(`
 		Delete the development environment for kube-bind.
-		
+
 		This command will delete the kind cluster created for kube-bind development.
 	`),
 		SilenceUsage: true,
@@ -151,7 +151,7 @@ func newDeleteCommand(streams genericclioptions.IOStreams) (*cobra.Command, erro
 				return err
 			}
 
-			return opts.RunDelete(cmd.Context())
+			return opts.RunDelete()
 		},
 	}
 	opts.AddCmdFlags(cmd)
@@ -182,7 +182,7 @@ func newExampleCommand(streams genericclioptions.IOStreams) (*cobra.Command, err
 				return err
 			}
 
-			return opts.RunPrintExample(cmd.Context())
+			return opts.RunPrintExample()
 		},
 	}
 	opts.AddCmdFlags(cmd)

--- a/cli/pkg/kubectl/dev/plugin/delete.go
+++ b/cli/pkg/kubectl/dev/plugin/delete.go
@@ -17,7 +17,6 @@ limitations under the License.
 package plugin
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -25,19 +24,19 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
-func (o *DevOptions) RunDelete(ctx context.Context) error {
-	if err := o.deleteCluster(ctx, o.ProviderClusterName); err != nil {
+func (o *DevOptions) RunDelete() error {
+	if err := o.deleteCluster(o.ProviderClusterName); err != nil {
 		return err
 	}
 
-	if err := o.deleteCluster(ctx, o.ConsumerClusterName); err != nil {
+	if err := o.deleteCluster(o.ConsumerClusterName); err != nil {
 		return err
 	}
 
-	return o.cleanupHostEntries(ctx)
+	return o.cleanupHostEntries()
 }
 
-func (o *DevOptions) deleteCluster(ctx context.Context, clusterName string) error {
+func (o *DevOptions) deleteCluster(clusterName string) error {
 	fmt.Fprintf(o.Streams.ErrOut, "Deleting kind cluster %s\n", clusterName)
 	provider := cluster.NewProvider()
 
@@ -56,7 +55,7 @@ func (o *DevOptions) deleteCluster(ctx context.Context, clusterName string) erro
 	return nil
 }
 
-func (o *DevOptions) cleanupHostEntries(ctx context.Context) error {
+func (o *DevOptions) cleanupHostEntries() error {
 	if err := removeHostEntry("kube-bind.dev.local"); err != nil {
 		fmt.Fprintf(o.Streams.ErrOut, "Failed to remove host entry: %v\n", err)
 		fmt.Fprintf(o.Streams.ErrOut, "Warning: Could not automatically remove host entry. Please run:\n")

--- a/cli/pkg/kubectl/dev/plugin/example.go
+++ b/cli/pkg/kubectl/dev/plugin/example.go
@@ -17,7 +17,6 @@ limitations under the License.
 package plugin
 
 import (
-	"context"
 	"fmt"
 )
 
@@ -29,7 +28,7 @@ metadata:
 spec:
   tier: Dedicated`
 
-func (o *DevOptions) RunPrintExample(ctx context.Context) error {
+func (o *DevOptions) RunPrintExample() error {
 	fmt.Fprintf(o.Streams.Out, "%s", example)
 	return nil
 }


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR adds the flag `kind-network` that allows to set the network for kind setup, this is useful when you have preconfigured networking in your local machine.
Also cleans up a bit of dev cmd code.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind feature

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Support `kind-network` flag in the dev command.
```
