### PR TITLE
Re-check previously owned

### DIFF
--- a/pkg/konnector/controllers/cluster/claimedresources/claimedresources_controller.go
+++ b/pkg/konnector/controllers/cluster/claimedresources/claimedresources_controller.go
@@ -237,7 +237,7 @@ func (c *controller) enqueueConsumer(logger klog.Logger, obj interface{}) {
 	// If owner label is set - it was claimed before and might not be claimed now (example: reference gone or changed).
 	// So we need to enqueue it to check if it is still needed.
 	_, wasClaimedBefore := o.GetLabels()[kubebindv1alpha2.ObjectOwnerLabel]
-	if !c.isClaimed(logger, o, true) && !wasClaimedBefore {
+	if !wasClaimedBefore && !c.isClaimed(logger, o, true) {
 		return
 	}
 	logger.V(2).Info("queueing consumer object", "gvr", o.GroupVersionKind().String(), "key", fmt.Sprintf("%s/%s", o.GetNamespace(), o.GetName()))
@@ -299,7 +299,7 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj interface{}) {
 	// If owner label is set - it was claimed before and might not be claimed now (example: reference gone or changed).
 	// So we need to enqueue it to check if it is still needed.
 	_, wasClaimedBefore := o.GetLabels()[kubebindv1alpha2.ObjectOwnerLabel]
-	if !c.isClaimed(logger, o, false) && !wasClaimedBefore {
+	if !wasClaimedBefore && !c.isClaimed(logger, o, false) {
 		logger.V(4).Info("object is not claimed, skipping", "object", o.GetObjectKind().GroupVersionKind(), "name", o.GetName())
 		return
 	}


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

If I create sync relationship using reference (Cert-Manager) and delete the object after - secret might be still lurking. For this, if we still have label indiciating that it was "claimed before"  - we need to re-check again. 

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Fix dangling reference objects
```
