### PR TITLE
clean up the omitempty tags and typo in sdk v1alpha2

### DIFF
--- a/sdk/apis/kubebind/v1alpha2/apiservicebinding_types.go
+++ b/sdk/apis/kubebind/v1alpha2/apiservicebinding_types.go
@@ -63,14 +63,14 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 type APIServiceBinding struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec specifies how an API service from a service provider should be bound in the
 	// local consumer cluster.
 	Spec APIServiceBindingSpec `json:"spec"`
 
 	// status contains reconciliation information for a service binding.
-	Status APIServiceBindingStatus `json:"status,omitempty"`
+	Status APIServiceBindingStatus `json:"status"`
 }
 
 func (in *APIServiceBinding) GetConditions() conditionsapi.Conditions {

--- a/sdk/apis/kubebind/v1alpha2/apiserviceexport_types.go
+++ b/sdk/apis/kubebind/v1alpha2/apiserviceexport_types.go
@@ -60,7 +60,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 type APIServiceExport struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec specifies the resource.
 	// +required
@@ -68,7 +68,7 @@ type APIServiceExport struct {
 	Spec APIServiceExportSpec `json:"spec"`
 
 	// status contains reconciliation information for the resource.
-	Status APIServiceExportStatus `json:"status,omitempty"`
+	Status APIServiceExportStatus `json:"status"`
 }
 
 func (in *APIServiceExport) GetConditions() conditionsapi.Conditions {

--- a/sdk/apis/kubebind/v1alpha2/apiserviceexportrequest_types.go
+++ b/sdk/apis/kubebind/v1alpha2/apiserviceexportrequest_types.go
@@ -45,7 +45,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 type APIServiceExportRequest struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec specifies how an API service from a service provider should be bound in the
 	// local consumer cluster.
@@ -234,7 +234,7 @@ type PermissionClaim struct {
 	// Selector is a resource selector that selects objects of a GVR.
 	// +required
 	// +kubebuilder:validation:Required
-	Selector Selector `json:"selector,omitempty"`
+	Selector Selector `json:"selector"`
 }
 
 // Owner is the owner of the resource.

--- a/sdk/apis/kubebind/v1alpha2/apiserviceexporttemplate_types.go
+++ b/sdk/apis/kubebind/v1alpha2/apiserviceexporttemplate_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 type APIServiceExportTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec specifies the template.
 	// +required
@@ -44,7 +44,7 @@ type APIServiceExportTemplate struct {
 	Spec APIServiceExportTemplateSpec `json:"spec"`
 
 	// status contains reconciliation information for the template.
-	Status APIServiceExportTemplateStatus `json:"status,omitempty"`
+	Status APIServiceExportTemplateStatus `json:"status"`
 }
 
 func (in *APIServiceExportTemplate) GetConditions() conditionsapi.Conditions {

--- a/sdk/apis/kubebind/v1alpha2/apiservicenamespace_types.go
+++ b/sdk/apis/kubebind/v1alpha2/apiservicenamespace_types.go
@@ -41,13 +41,13 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 type APIServiceNamespace struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec specifies a service namespace.
 	Spec APIServiceNamespaceSpec `json:"spec"`
 
 	// status contains reconciliation information for a service namespace
-	Status APIServiceNamespaceStatus `json:"status,omitempty"`
+	Status APIServiceNamespaceStatus `json:"status"`
 }
 
 type APIServiceNamespaceSpec struct {

--- a/sdk/apis/kubebind/v1alpha2/bindingresponse_types.go
+++ b/sdk/apis/kubebind/v1alpha2/bindingresponse_types.go
@@ -84,9 +84,9 @@ type BindingResponseAuthenticationOAuth2CodeGrant struct {
 // authentication and resource selection on the service provider website.
 type BindableResourcesRequest struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
-	TemplateRef APIServiceExportTemplateRef `json:"templateRef,omitempty"`
+	TemplateRef APIServiceExportTemplateRef `json:"templateRef"`
 }
 
 type APIServiceExportTemplateRef struct {

--- a/sdk/apis/kubebind/v1alpha2/boundschema_types.go
+++ b/sdk/apis/kubebind/v1alpha2/boundschema_types.go
@@ -41,10 +41,10 @@ type ExportedSchemas map[string]*BoundSchema
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type BoundSchema struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   BoundSchemaSpec   `json:"spec"`
-	Status BoundSchemaStatus `json:"status,omitempty"`
+	Status BoundSchemaStatus `json:"status"`
 }
 
 // ResourceGroupName returns the group name of the resource.

--- a/sdk/apis/kubebind/v1alpha2/clusterbinding_types.go
+++ b/sdk/apis/kubebind/v1alpha2/clusterbinding_types.go
@@ -50,7 +50,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == \"cluster\"",message="cluster binding name should be cluster"
 type ClusterBinding struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec represents the data in the newly created ClusterBinding.
 	// +required
@@ -58,7 +58,7 @@ type ClusterBinding struct {
 	Spec ClusterBindingSpec `json:"spec"`
 
 	// status contains reconciliation information for the service binding.
-	Status ClusterBindingStatus `json:"status,omitempty"`
+	Status ClusterBindingStatus `json:"status"`
 }
 
 func (in *ClusterBinding) GetConditions() conditionsapi.Conditions {

--- a/sdk/apis/kubebind/v1alpha2/collection_types.go
+++ b/sdk/apis/kubebind/v1alpha2/collection_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 type Collection struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// spec specifies the collection.
 	// +required
@@ -43,7 +43,7 @@ type Collection struct {
 	Spec CollectionSpec `json:"spec"`
 
 	// status contains reconciliation information for the collection.
-	Status CollectionStatus `json:"status,omitempty"`
+	Status CollectionStatus `json:"status"`
 }
 
 func (in *Collection) GetConditions() conditionsapi.Conditions {


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Clean up the omitempty tags on the nested structs, as they have no effect.
Rename the boundschema_types.go filename typo.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind cleanup

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
