### PR TITLE
Fix existing cluster flow in dev create

### DIFF
--- a/cli/pkg/kubectl/dev/plugin/create.go
+++ b/cli/pkg/kubectl/dev/plugin/create.go
@@ -235,6 +235,12 @@ func (o *DevOptions) createCluster(ctx context.Context, clusterName, clusterConf
 
 	if slices.Contains(clusters, clusterName) {
 		fmt.Fprint(o.Streams.ErrOut, "Kind cluster "+clusterName+" already exists, skipping creation\n")
+
+		// Export kubeconfig for existing cluster
+		err := provider.ExportKubeConfig(clusterName, kubeconfigPath, false)
+		if err != nil {
+			return fmt.Errorf("failed to export kubeconfig for existing cluster %s: %w", clusterName, err)
+		}
 	} else {
 		fmt.Fprintf(o.Streams.ErrOut, "Creating kind cluster %s with network %s\n", clusterName, o.KindNetwork)
 		err := provider.Create(clusterName,


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

If kind cluster already exist it will expect kubeconfig files to be present. 

## What Type of PR Is This?
/kind bug
<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
