### PR TITLE
fix: bump helm chart version in bind dev command

### DIFF
--- a/cli/pkg/kubectl/dev/plugin/create.go
+++ b/cli/pkg/kubectl/dev/plugin/create.go
@@ -46,7 +46,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
-
 	"sigs.k8s.io/kind/pkg/cluster"
 
 	"github.com/kube-bind/kube-bind/cli/pkg/kubectl/base"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Bump chart version with up to date CRDs in the kubectl bind dev command.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind bug

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
