### PR TITLE
konnector: fix nil ptr deref in multins informer

### DIFF
--- a/pkg/konnector/controllers/cluster/serviceexport/multinsinformer/informer.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/multinsinformer/informer.go
@@ -167,7 +167,11 @@ func (inf *DynamicMultiNamespaceInformer) enqueueServiceNamespace(obj any) {
 		inf.lock.Lock()
 		defer inf.lock.Unlock()
 		if cancel, found := inf.namespaceCancel[name]; found {
-			logger.V(2).Info("stopping informer", "namespace", sns.Status.Namespace)
+			if sns == nil {
+				logger.V(2).Info("stopping informer")
+			} else {
+				logger.V(2).Info("stopping informer", "namespace", sns.Status.Namespace)
+			}
 			delete(inf.namespaceCancel, name)
 			delete(inf.namespaceInformers, name)
 			cancel()


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

This PR adds a check to konnector's multins informer and logs APIServiceNamespace's `.status.namespace` only if the sns exists.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind bug

## Related Issue(s)

Fixes https://github.com/kube-bind/kube-bind/issues/449

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
