### PR TITLE
Allign backend image flags with konnector ones

### DIFF
--- a/cli/pkg/kubectl/dev/plugin/create.go
+++ b/cli/pkg/kubectl/dev/plugin/create.go
@@ -60,8 +60,8 @@ type DevOptions struct {
 	Logs    *logs.Options
 	Streams genericclioptions.IOStreams
 
-	Image               string
-	Tag                 string
+	BackendImage        string
+	BackendTag          string
 	ProviderClusterName string
 	ConsumerClusterName string
 	WaitForReadyTimeout time.Duration
@@ -102,8 +102,8 @@ func (o *DevOptions) AddCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().DurationVar(&o.WaitForReadyTimeout, "wait-for-ready-timeout", 2*time.Minute, "Timeout for waiting for the cluster to be ready")
 	cmd.Flags().StringVar(&o.ChartPath, "chart-path", o.ChartPath, "Helm chart path or OCI registry URL")
 	cmd.Flags().StringVar(&o.ChartVersion, "chart-version", o.ChartVersion, "The version of the Helm chart to use")
-	cmd.Flags().StringVar(&o.Image, "image", "ghcr.io/kube-bind/backend", "The name of kube-bind backend to use in dev mode")
-	cmd.Flags().StringVar(&o.Tag, "tag", "", "The tag of the kube-bind backend image to use in dev mode")
+	cmd.Flags().StringVar(&o.BackendImage, "backend-image", "ghcr.io/kube-bind/backend", "The name of kube-bind backend to use in dev mode")
+	cmd.Flags().StringVar(&o.BackendTag, "backend-tag", "", "The tag of the kube-bind backend image to use in dev mode")
 	cmd.Flags().StringVar(&o.KindNetwork, "kind-network", "kube-bind-dev", "The name of the kind network to use in dev mode")
 }
 
@@ -111,7 +111,7 @@ func (o *DevOptions) AddCmdFlags(cmd *cobra.Command) {
 func (o *DevOptions) Complete(args []string) error {
 	// Only fetch the latest version if tag is not set
 	var assetVersion string
-	if o.Tag == "" {
+	if o.BackendTag == "" {
 		version, err := fetchLatestRelease()
 		if err != nil {
 			// Log the error but continue with fallback version
@@ -125,8 +125,8 @@ func (o *DevOptions) Complete(args []string) error {
 		if o.ChartVersion == "" || o.ChartVersion == fallbackAssetVersion {
 			o.ChartVersion = assetVersion
 		}
-		if o.Tag == "" || o.Tag == "v"+fallbackAssetVersion {
-			o.Tag = "v" + assetVersion
+		if o.BackendTag == "" || o.BackendTag == "v"+fallbackAssetVersion {
+			o.BackendTag = "v" + assetVersion
 		}
 	}
 
@@ -391,14 +391,14 @@ func (o *DevOptions) installHelmChart(_ context.Context, restConfig *rest.Config
 	actionConfig.RegistryClient = registryClient
 
 	values := map[string]any{
-		"image": map[string]any{
-			"repository": o.Image,
-			"tag":        o.Tag,
-		},
 		"examples": map[string]any{
 			"enabled": true,
 		},
 		"backend": map[string]any{
+			"image": map[string]any{
+				"repository": o.BackendImage,
+				"tag":        o.BackendTag,
+			},
 			"listenAddress":      "0.0.0.0:8080",
 			"namespacePrefix":    "kube-bind-",
 			"externalAddress":    "https://kube-bind.dev.local:6443",

--- a/deploy/charts/backend/README.md
+++ b/deploy/charts/backend/README.md
@@ -34,6 +34,9 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | backend.externalServerName | string | `""` | External server name for TLS SNI |
 | backend.extraArgs | list | `[]` | Extra command-line arguments to pass to the backend |
 | backend.frontendDisabled | bool | `false` | Disable the frontend UI |
+| backend.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| backend.image.repository | string | `"ghcr.io/kube-bind/backend"` | Image repository |
+| backend.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | backend.kubeconfig | string | `""` | Path to a kubeconfig file. Only required if out-of-cluster. |
 | backend.listenAddress | string | `"0.0.0.0:8080"` | Address the backend listens on |
 | backend.loggingLevel | int | `2` | Logging verbosity level |
@@ -71,9 +74,6 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | gatewayApi.route.path | string | `"/"` | Path match for the HTTPRoute |
 | gatewayApi.route.pathType | string | `"PathPrefix"` | Path match type for the HTTPRoute |
 | hostAliases | list | `[]` | Host aliases for /etc/hosts injection into pods |
-| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/kube-bind/backend"` | Image repository |
-| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | Secrets for pulling images from a private repository |
 | initContainers | list | `[]` | Additional init containers |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Liveness probe configuration |

--- a/deploy/charts/backend/templates/deployment.yaml
+++ b/deploy/charts/backend/templates/deployment.yaml
@@ -46,8 +46,8 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           env:
           {{- if .Values.backend.oidc.clientSecretName }}
             - name: OIDC_CLIENT_SECRET

--- a/deploy/charts/backend/values.yaml
+++ b/deploy/charts/backend/values.yaml
@@ -7,6 +7,14 @@ replicaCount: 1
 
 # Backend configuration
 backend:
+  # Container image configuration
+  image:
+    # -- Image repository
+    repository: ghcr.io/kube-bind/backend
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the chart appVersion
+    tag: ""
   # -- Address the backend listens on
   listenAddress: "0.0.0.0:8080"
   # -- Path to a kubeconfig file. Only required if out-of-cluster.
@@ -129,15 +137,6 @@ gatewayApi:
 examples:
   # -- Enable example resources to seed on first start
   enabled: false
-
-# Container image configuration
-image:
-  # -- Image repository
-  repository: ghcr.io/kube-bind/backend
-  # -- Image pull policy
-  pullPolicy: IfNotPresent
-  # -- Overrides the image tag whose default is the chart appVersion
-  tag: ""
 
 # -- Secrets for pulling images from a private repository
 imagePullSecrets: []


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Refactored Helm image config under backend and renamed image flags under `kubectl bind dev` to --backend-image / --backend-tag for consistent image overrides like konnector.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
Backend image configuration now lives under backend Helm settings, `--image` and `--tag` was replaced by `--backend-image` and `--backend-tag`.
```
