### PR TITLE
Fix helm chart image version

### DIFF
--- a/hack/helm-build.sh
+++ b/hack/helm-build.sh
@@ -33,7 +33,7 @@ for chart_dir in deploy/charts/*/; do
 
       cp "${chart_dir}Chart.yaml" "${chart_dir}Chart.yaml.bak"
       sed -i.tmp "s/^version:.*/version: $CHART_VERSION/" "${chart_dir}Chart.yaml"
-      sed -i.tmp "s/^appVersion:.*/appVersion: $CHART_VERSION/" "${chart_dir}Chart.yaml"
+      sed -i.tmp "s/^appVersion:.*/appVersion: v$CHART_VERSION/" "${chart_dir}Chart.yaml"
       rm -f "${chart_dir}Chart.yaml.tmp"
 
       "$HELM" package "$chart_dir" --version "$CHART_VERSION" --destination ./bin/


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

## What Type of PR Is This?

Make the default image tag tolerate both v-prefixed and unprefixed `Chart.appVersion` by stripping any leading v and always prepending one. Fixes installs failing with `ImagePullBackOff` when `appVersion` is published without the v prefix (e.g. `0.8.1` (how helm charts does it) while images are tagged v0.8.1.

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
