### PR TITLE
Fix packages retention in gh action image

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -83,7 +83,14 @@ jobs:
 
     - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
       with:
-        package-name: '${{ github.event.repository.name }}'
+        package-name: 'konnector'
+        package-type: 'container'
+        min-versions-to-keep: 10
+        delete-only-pre-release-versions: "true"
+
+    - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+      with:
+        package-name: 'backend'
         package-type: 'container'
         min-versions-to-keep: 10
         delete-only-pre-release-versions: "true"

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -94,3 +94,10 @@ jobs:
         package-type: 'container'
         min-versions-to-keep: 10
         delete-only-pre-release-versions: "true"
+
+    - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+      with:
+        package-name: 'charts/backend'
+        package-type: 'container'
+        min-versions-to-keep: 10
+        delete-only-pre-release-versions: "true"


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

It seems like we have been trying to clean-up non existent package 'kube-bind', old gh action did not report any issue.
This PR sets it for both backend and konnector packages.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind cleanup
## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
