### PR TITLE
fix the helm versioning of kube-bind backend Helm chart

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -55,12 +55,11 @@ jobs:
           echo "org.opencontainers.image.version=${{ github.ref_name }}"
           echo 'EOF'
         } >> "$GITHUB_ENV"
-        # Helm chart version: semver from tag, otherwise 0.0.0-<sha>
+        # App version: full tag (e.g. v0.8.1) for releases, otherwise 0.0.0-<sha>
         if [[ "${{ github.ref_type }}" == "tag" ]]; then
-          chart_version="${{ github.ref_name }}"
-          echo "CHART_VERSION=${chart_version#v}" >> "$GITHUB_ENV"
+          echo "APP_VERSION=${{ github.ref_name }}" >> "$GITHUB_ENV"
         else
-          echo "CHART_VERSION=0.0.0-${{ github.sha }}" >> "$GITHUB_ENV"
+          echo "APP_VERSION=0.0.0-${{ github.sha }}" >> "$GITHUB_ENV"
         fi
 
     - name: Login to GitHub Container Registry

--- a/Makefile
+++ b/Makefile
@@ -420,11 +420,12 @@ build-web:
 # Image / release configuration.
 # IMAGE_TAGS is the space-separated list of tag suffixes applied to each component image.
 # IMAGE_PUSH_PLATFORMS is the platform list for `image-push` (multi-arch by default).
-# CHART_VERSION is the helm chart version; defaults to 0.0.0-$REV.
+# APP_VERSION is the application version passed to helm-build.sh; defaults to 0.0.0-$REV.
+# helm-build.sh strips the leading "v" to derive a valid Helm chart semver.
 # IMAGE_METADATA_DIR holds buildx metadata files used by `image-sign`.
 export IMAGE_TAGS ?= $(REV)
 IMAGE_PUSH_PLATFORMS ?= linux/amd64,linux/arm64
-export CHART_VERSION ?= 0.0.0-$(REV)
+export APP_VERSION ?= 0.0.0-$(REV)
 IMAGE_METADATA_DIR ?= $(BUILD_DIR)/image-metadata
 
 # Example: make IMAGE_REPO=ghcr.io/<username> image-local

--- a/cli/pkg/kubectl/dev/plugin/create.go
+++ b/cli/pkg/kubectl/dev/plugin/create.go
@@ -70,7 +70,7 @@ type DevOptions struct {
 }
 
 // fallbackAssetVersion is used when unable to fetch the latest version
-const fallbackAssetVersion = "0.7.1"
+const fallbackAssetVersion = "0.8.1"
 
 // gitHubRelease represents a GitHub release response
 type gitHubRelease struct {

--- a/deploy/charts/backend/Chart.yaml
+++ b/deploy/charts/backend/Chart.yaml
@@ -15,10 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+# NOTE: updated by helm-build.sh during the build — do not edit manually.
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.1"
+# NOTE: updated by helm-build.sh during the build — do not edit manually.
+appVersion: "0.0.0"

--- a/deploy/charts/backend/README.md
+++ b/deploy/charts/backend/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for kube-bind backend deployment
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.1](https://img.shields.io/badge/AppVersion-v0.7.1-informational?style=flat-square)
+![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 ## Installation
 

--- a/hack/helm-build.sh
+++ b/hack/helm-build.sh
@@ -16,13 +16,13 @@
 
 set -eu
 
-# Inputs (env vars):
-#   REV             short git sha (required if CHART_VERSION is unset)
-#   CHART_VERSION   chart version string; default: 0.0.0-$REV
+APP_VERSION="${APP_VERSION:-0.0.0-${REV:-}}"
+if [[ -z "$APP_VERSION" || "$APP_VERSION" == "0.0.0-" ]]; then
+  echo "ERROR: APP_VERSION or REV must be set" >&2; exit 1
+fi
+CHART_VERSION="${APP_VERSION#v}"
 
-: "${CHART_VERSION:=0.0.0-${REV:?REV must be set when CHART_VERSION is unset}}"
-
-echo "Building Helm charts (version: $CHART_VERSION)..."
+echo "Building Helm charts (appVersion: $APP_VERSION, chartVersion: $CHART_VERSION)..."
 
 HELM="$(UGET_PRINT_PATH=absolute make --no-print-directory install-helm)"
 
@@ -33,7 +33,7 @@ for chart_dir in deploy/charts/*/; do
 
       cp "${chart_dir}Chart.yaml" "${chart_dir}Chart.yaml.bak"
       sed -i.tmp "s/^version:.*/version: $CHART_VERSION/" "${chart_dir}Chart.yaml"
-      sed -i.tmp "s/^appVersion:.*/appVersion: $CHART_VERSION/" "${chart_dir}Chart.yaml"
+      sed -i.tmp "s/^appVersion:.*/appVersion: \"$APP_VERSION\"/" "${chart_dir}Chart.yaml"
       rm -f "${chart_dir}Chart.yaml.tmp"
 
       "$HELM" package "$chart_dir" --version "$CHART_VERSION" --destination ./bin/


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Helm chart versioning is now driven by APP_VERSION (e.g. v0.8.1) across the workflow, Makefile, and build script — the v is stripped inside helm-build.sh to satisfy Helm's semver requirement. Chart.yaml now has placeholder 0.0.0 values with a comment making clear they're overwritten on every build. The dev create fallback version was also bumped to 0.8.1. Build was verified locally.

Based on @xrstf comment https://github.com/kube-bind/kube-bind/pull/546#discussion_r3266523650

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->
/kind cleanup
## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
