### PR TITLE
Stop auto-deleting container package versions

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -79,24 +79,3 @@ jobs:
 
     - name: Build and push Helm charts
       run: make release-helm
-
-    - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-      with:
-        package-name: 'konnector'
-        package-type: 'container'
-        min-versions-to-keep: 10
-        delete-only-pre-release-versions: "true"
-
-    - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-      with:
-        package-name: 'backend'
-        package-type: 'container'
-        min-versions-to-keep: 10
-        delete-only-pre-release-versions: "true"
-
-    - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-      with:
-        package-name: 'charts/backend'
-        package-type: 'container'
-        min-versions-to-keep: 10
-        delete-only-pre-release-versions: "true"


### PR DESCRIPTION
## What

Removes the three `actions/delete-package-versions` steps from `.github/workflows/image.yaml` that pruned old **pre-release** versions of `konnector`, `backend`, and `charts/backend`.

## Why

This workflow runs on **every push to `main`** (and `v*` tags). The cleanup steps were firing on each merge and deleting container image versions we want to keep — surfacing as recurring `github-actions[bot]` → `packages.package_version_deleted` audit events.

Removing the auto-prune; retention can be managed manually (or re-added later scoped to tags only, with a higher `min-versions-to-keep`) if disk usage ever becomes a concern.