### PR TITLE
helm: konnector: expose hostAliases

### DIFF
--- a/deploy/charts/konnector/templates/deployment.yaml
+++ b/deploy/charts/konnector/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/charts/konnector/values.yaml
+++ b/deploy/charts/konnector/values.yaml
@@ -53,6 +53,14 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# Host aliases injected into /etc/hosts.
+# Needed when circumventing local DNS (e.g. local setup).
+hostAliases: []
+# Example:
+# - ip: "1.2.3.4"
+#   hostnames:
+#     - kcp.api.portal.localhost
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Summary

This PR exposes `hostAliases` in konnector's helm chart. Useful in local setup envs where DNS is weird.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
