### PR TITLE
feat: implement multi-provider binding support for CRDs (#173)

### DIFF
--- a/backend/controllers/bindableresourcesrequest/bindableresourcesrequest_controller.go
+++ b/backend/controllers/bindableresourcesrequest/bindableresourcesrequest_controller.go
@@ -273,7 +273,7 @@ func (r *reconciler) reconcile(ctx context.Context, clusterName string, cl clien
 	req.Status.Namespace = result.Namespace
 
 	// Create or update the BindingResourceResponse secret
-	if err := r.ensureBindingResponseSecret(ctx, cl, req, result.Kubeconfig, secretName, secretKey); err != nil {
+	if err := r.ensureBindingResponseSecret(ctx, cl, req, result, secretName, secretKey); err != nil {
 		meta.SetStatusCondition(&req.Status.Conditions, metav1.Condition{
 			Type:               string(kubebindv1alpha2.BindableResourcesRequestConditionReady),
 			Status:             metav1.ConditionFalse,
@@ -306,25 +306,26 @@ func (r *reconciler) reconcile(ctx context.Context, clusterName string, cl clien
 	return ctrl.Result{}, nil
 }
 
-// ensureBindingResponseSecret creates or updates a secret containing the BindingResourceResponse
-// with only the kubeconfig set (no authentication or requests).
+// with only the kubeconfig, providerID, and providerNamespace set (no authentication or requests).
 func (r *reconciler) ensureBindingResponseSecret(
 	ctx context.Context,
 	cl client.Client,
 	req *kubebindv1alpha2.BindableResourcesRequest,
-	kubeconfig []byte,
+	result *kubernetes.HandleResourcesResult,
 	secretName string,
 	secretKey string,
 ) error {
 	logger := log.FromContext(ctx)
 
-	// Create the BindingResourceResponse with only kubeconfig
+	// Create the BindingResourceResponse
 	response := kubebindv1alpha2.BindingResourceResponse{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kubebindv1alpha2.SchemeGroupVersion.String(),
 			Kind:       "BindingResourceResponse",
 		},
-		Kubeconfig: kubeconfig,
+		Kubeconfig:        result.Kubeconfig,
+		ProviderNamespace: result.Namespace,
+		ProviderID:        result.ProviderID,
 	}
 
 	responseBytes, err := json.Marshal(&response)

--- a/backend/http/handler.go
+++ b/backend/http/handler.go
@@ -513,6 +513,7 @@ func (h *handler) handleBind(w http.ResponseWriter, r *http.Request) {
 		Kubeconfig:        handleResult.Kubeconfig,
 		Requests:          []runtime.RawExtension{{Raw: requestBytes}},
 		ProviderNamespace: handleResult.Namespace,
+		ProviderID:        handleResult.ProviderID,
 		BindingName:       exportRequestName,
 	}
 

--- a/backend/kubernetes/manager.go
+++ b/backend/kubernetes/manager.go
@@ -103,6 +103,8 @@ type HandleResourcesResult struct {
 	Kubeconfig []byte
 	// Namespace is the namespace assigned to this binding on the service provider cluster.
 	Namespace string
+	// ProviderID is the UID of the kube-system namespace of the provider cluster.
+	ProviderID string
 }
 
 func (m *Manager) HandleResources(
@@ -181,9 +183,15 @@ func (m *Manager) HandleResources(
 		return nil, err
 	}
 
+	var kubeSystemNS corev1.Namespace
+	if err := c.Get(ctx, types.NamespacedName{Name: "kube-system"}, &kubeSystemNS); err != nil {
+		return nil, fmt.Errorf("failed to get kube-system namespace for ProviderID: %w", err)
+	}
+
 	return &HandleResourcesResult{
 		Kubeconfig: kfgSecret.Data["kubeconfig"],
 		Namespace:  ns,
+		ProviderID: string(kubeSystemNS.UID),
 	}, nil
 }
 

--- a/cli/pkg/kubectl/bind-apiservice/plugin/binder.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/binder.go
@@ -155,7 +155,7 @@ func (b *Binder) BindFromFile(ctx context.Context) ([]*kubebindv1alpha2.APIServi
 		return nil, fmt.Errorf("failed to create kubeconfig secret: %w", err)
 	}
 
-	results, err := b.createAPIServiceBindings(ctx, result, secretName)
+	results, err := b.createAPIServiceBindings(ctx, result, secretName, "", false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API service bindings: %w", err)
 	}
@@ -247,7 +247,7 @@ func (b *Binder) BindFromResponse(ctx context.Context, response *kubebindv1alpha
 			return nil, fmt.Errorf("failed to create kubeconfig secret: %w", err)
 		}
 
-		results, err := b.createAPIServiceBindings(ctx, result, secretName)
+		results, err := b.createAPIServiceBindings(ctx, result, secretName, response.ProviderID, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create API service bindings: %w", err)
 		}
@@ -304,11 +304,11 @@ func (b *Binder) createKubeconfigSecret(ctx context.Context, remoteHost, remoteN
 	return tempOpts.createKubeconfigSecret(ctx, b.config, remoteHost, remoteNamespace, remoteKubeconfig)
 }
 
-func (b *Binder) createAPIServiceBindings(ctx context.Context, request *kubebindv1alpha2.APIServiceExportRequest, secretName string) ([]*kubebindv1alpha2.APIServiceBinding, error) {
+func (b *Binder) createAPIServiceBindings(ctx context.Context, request *kubebindv1alpha2.APIServiceExportRequest, secretName string, providerID string, isDefault bool) ([]*kubebindv1alpha2.APIServiceBinding, error) {
 	tempOpts := &BindAPIServiceOptions{
 		Options: &base.Options{IOStreams: b.opts.IOStreams},
 	}
-	return tempOpts.createAPIServiceBindings(ctx, b.config, request, secretName)
+	return tempOpts.createAPIServiceBindings(ctx, b.config, request, secretName, providerID, isDefault)
 }
 
 func (b *Binder) getRequestManifest() ([]byte, error) {

--- a/cli/pkg/kubectl/bind-apiservice/plugin/servicebindings.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/servicebindings.go
@@ -34,7 +34,7 @@ import (
 	bindclient "github.com/kube-bind/kube-bind/sdk/client/clientset/versioned"
 )
 
-func (b *BindAPIServiceOptions) createAPIServiceBindings(ctx context.Context, config *rest.Config, request *kubebindv1alpha2.APIServiceExportRequest, secretName string) ([]*kubebindv1alpha2.APIServiceBinding, error) {
+func (b *BindAPIServiceOptions) createAPIServiceBindings(ctx context.Context, config *rest.Config, request *kubebindv1alpha2.APIServiceExportRequest, secretName string, providerID string, isDefault bool) ([]*kubebindv1alpha2.APIServiceBinding, error) {
 	bindClient, err := bindclient.NewForConfig(config)
 	if err != nil {
 		return nil, err
@@ -86,6 +86,8 @@ func (b *BindAPIServiceOptions) createAPIServiceBindings(ctx context.Context, co
 					},
 					Namespace: "kube-bind",
 				},
+				ProviderID: providerID,
+				IsDefault:  isDefault,
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {

--- a/contrib/kcp/deploy/resources/apiexport-kube-bind.io.yaml
+++ b/contrib/kcp/deploy/resources/apiexport-kube-bind.io.yaml
@@ -61,7 +61,7 @@ spec:
       crd: {}
   - group: kube-bind.io
     name: apiservicebindings
-    schema: v260122-c9f0f376.apiservicebindings.kube-bind.io
+    schema: v260716-5d02230.apiservicebindings.kube-bind.io
     storage:
       crd: {}
   - group: kube-bind.io

--- a/contrib/kcp/deploy/resources/apiresourceschema-apiservicebindings.kube-bind.io.yaml
+++ b/contrib/kcp/deploy/resources/apiresourceschema-apiservicebindings.kube-bind.io.yaml
@@ -1,7 +1,7 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  name: v260122-c9f0f376.apiservicebindings.kube-bind.io
+  name: v260716-5d02230.apiservicebindings.kube-bind.io
 spec:
   conversion:
     strategy: None
@@ -196,6 +196,11 @@ spec:
             spec specifies how an API service from a service provider should be bound in the
             local consumer cluster.
           properties:
+            isDefault:
+              description: |-
+                isDefault indicates whether this binding should be used as the default routing
+                destination for Custom Resources that do not specify a provider annotation.
+              type: boolean
             kubeconfigSecretRef:
               description: kubeconfigSecretName is the secret ref that contains the
                 kubeconfig of the service cluster.
@@ -219,6 +224,10 @@ spec:
               x-kubernetes-validations:
               - message: kubeconfigSecretRef is immutable
                 rule: self == oldSelf
+            providerID:
+              description: providerID is a stable and unique identifier for the provider
+                cluster.
+              type: string
           required:
           - kubeconfigSecretRef
           type: object

--- a/deploy/charts/backend/crds/kube-bind.io_apiservicebindings.yaml
+++ b/deploy/charts/backend/crds/kube-bind.io_apiservicebindings.yaml
@@ -201,6 +201,11 @@ spec:
               spec specifies how an API service from a service provider should be bound in the
               local consumer cluster.
             properties:
+              isDefault:
+                description: |-
+                  isDefault indicates whether this binding should be used as the default routing
+                  destination for Custom Resources that do not specify a provider annotation.
+                type: boolean
               kubeconfigSecretRef:
                 description: kubeconfigSecretName is the secret ref that contains
                   the kubeconfig of the service cluster.
@@ -224,6 +229,10 @@ spec:
                 x-kubernetes-validations:
                 - message: kubeconfigSecretRef is immutable
                   rule: self == oldSelf
+              providerID:
+                description: providerID is a stable and unique identifier for the
+                  provider cluster.
+                type: string
             required:
             - kubeconfigSecretRef
             type: object

--- a/deploy/crd/kube-bind.io_apiservicebindings.yaml
+++ b/deploy/crd/kube-bind.io_apiservicebindings.yaml
@@ -202,6 +202,11 @@ spec:
               spec specifies how an API service from a service provider should be bound in the
               local consumer cluster.
             properties:
+              isDefault:
+                description: |-
+                  isDefault indicates whether this binding should be used as the default routing
+                  destination for Custom Resources that do not specify a provider annotation.
+                type: boolean
               kubeconfigSecretRef:
                 description: kubeconfigSecretName is the secret ref that contains
                   the kubeconfig of the service cluster.
@@ -225,6 +230,10 @@ spec:
                 x-kubernetes-validations:
                 - message: kubeconfigSecretRef is immutable
                   rule: self == oldSelf
+              providerID:
+                description: providerID is a stable and unique identifier for the
+                  provider cluster.
+                type: string
             required:
             - kubeconfigSecretRef
             type: object

--- a/pkg/konnector/controllers/cluster/serviceexport/serviceexport_reconcile.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/serviceexport_reconcile.go
@@ -139,7 +139,7 @@ func (r *reconciler) ensureControllers(ctx context.Context, namespace, name stri
 		}
 
 		// Start/update controller for this schema
-		if err := r.ensureControllerForSchema(ctx, export, schema); err != nil {
+		if err := r.ensureControllerForSchema(ctx, export, binding, schema); err != nil {
 			errs = append(errs, err)
 		}
 
@@ -170,7 +170,7 @@ func (r *reconciler) ensureControllers(ctx context.Context, namespace, name stri
 	return utilerrors.NewAggregate(errs)
 }
 
-func (r *reconciler) ensureControllerForSchema(ctx context.Context, export *kubebindv1alpha2.APIServiceExport, schema *kubebindv1alpha2.BoundSchema) error {
+func (r *reconciler) ensureControllerForSchema(ctx context.Context, export *kubebindv1alpha2.APIServiceExport, binding *kubebindv1alpha2.APIServiceBinding, schema *kubebindv1alpha2.BoundSchema) error {
 	logger := klog.FromContext(ctx)
 	key := contextstore.NewKey(export.Namespace, export.Name, schema.Name)
 
@@ -296,6 +296,8 @@ func (r *reconciler) ensureControllerForSchema(ctx context.Context, export *kube
 		consumerInf.ForResource(gvr),
 		providerInf,
 		r.serviceNamespaceInformer,
+		binding.Spec.ProviderID,
+		binding.Spec.IsDefault,
 	)
 	if err != nil {
 		runtime.HandleError(err)
@@ -312,6 +314,8 @@ func (r *reconciler) ensureControllerForSchema(ctx context.Context, export *kube
 		consumerInf.ForResource(gvr),
 		providerInf,
 		r.serviceNamespaceInformer,
+		binding.Spec.ProviderID,
+		binding.Spec.IsDefault,
 	)
 	if err != nil {
 		runtime.HandleError(err)

--- a/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/spec/spec_controller.go
@@ -63,6 +63,8 @@ func NewController(
 	consumerDynamicInformer informers.GenericInformer,
 	providerDynamicInformer multinsinformer.GetterInformer,
 	serviceNamespaceInformer dynamic.Informer[bindlisters.APIServiceNamespaceLister],
+	providerID string,
+	isDefault bool,
 ) (*controller, error) {
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName})
 
@@ -150,12 +152,21 @@ func NewController(
 
 	if _, err := consumerDynamicInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
+			if !shouldProcess(obj, providerID, isDefault) {
+				return
+			}
 			c.enqueueConsumer(logger, obj)
 		},
 		UpdateFunc: func(_, newObj any) {
+			if !shouldProcess(newObj, providerID, isDefault) {
+				return
+			}
 			c.enqueueConsumer(logger, newObj)
 		},
 		DeleteFunc: func(obj any) {
+			if !shouldProcess(obj, providerID, isDefault) {
+				return
+			}
 			c.enqueueConsumer(logger, obj)
 		},
 	}); err != nil {
@@ -206,7 +217,31 @@ func (c *controller) enqueueConsumer(logger klog.Logger, obj any) {
 	}
 
 	logger.V(2).Info("queueing Unstructured", "queued", key, "reason", "consumerObject")
-	c.queue.Add(key)
+}
+
+func shouldProcess(obj any, providerID string, isDefault bool) bool {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		// Try DeletedFinalStateUnknown
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return false
+		}
+		u, ok = tombstone.Obj.(*unstructured.Unstructured)
+		if !ok {
+			return false
+		}
+	}
+
+	annotations := u.GetAnnotations()
+	if annotations == nil {
+		return isDefault
+	}
+	val, ok := annotations["provider.kube-bind.io/provider-id"]
+	if !ok || val == "" {
+		return isDefault
+	}
+	return val == providerID
 }
 
 func (c *controller) enqueueProvider(logger klog.Logger, obj any) {

--- a/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
+++ b/pkg/konnector/controllers/cluster/serviceexport/status/status_controller.go
@@ -57,6 +57,8 @@ func NewController(
 	consumerDynamicInformer informers.GenericInformer,
 	providerDynamicInformer multinsinformer.GetterInformer,
 	serviceNamespaceInformer dynamic.Informer[bindlisters.APIServiceNamespaceLister],
+	providerID string,
+	isDefault bool,
 ) (*controller, error) {
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName})
 
@@ -124,12 +126,21 @@ func NewController(
 
 	if _, err := consumerDynamicInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
+			if !shouldProcess(obj, providerID, isDefault) {
+				return
+			}
 			c.enqueueConsumer(logger, obj)
 		},
 		UpdateFunc: func(_, newObj any) {
+			if !shouldProcess(newObj, providerID, isDefault) {
+				return
+			}
 			c.enqueueConsumer(logger, newObj)
 		},
 		DeleteFunc: func(obj any) {
+			if !shouldProcess(obj, providerID, isDefault) {
+				return
+			}
 			c.enqueueConsumer(logger, obj)
 		},
 	}); err != nil {
@@ -204,7 +215,31 @@ func (c *controller) enqueueProvider(logger klog.Logger, obj any) {
 	}
 
 	logger.V(2).Info("queueing Unstructured", "queued", key)
-	c.queue.Add(key)
+}
+
+func shouldProcess(obj any, providerID string, isDefault bool) bool {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		// Try DeletedFinalStateUnknown
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return false
+		}
+		u, ok = tombstone.Obj.(*unstructured.Unstructured)
+		if !ok {
+			return false
+		}
+	}
+
+	annotations := u.GetAnnotations()
+	if annotations == nil {
+		return isDefault
+	}
+	val, ok := annotations["provider.kube-bind.io/provider-id"]
+	if !ok || val == "" {
+		return isDefault
+	}
+	return val == providerID
 }
 
 func (c *controller) enqueueConsumer(logger klog.Logger, obj any) {

--- a/pkg/konnector/controllers/servicebindingbundle/servicebindingbundle_reconcile.go
+++ b/pkg/konnector/controllers/servicebindingbundle/servicebindingbundle_reconcile.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -183,6 +184,27 @@ func (r *reconciler) syncAPIServiceBindings(ctx context.Context, bundle *kubebin
 		return err
 	}
 
+	// Create a standard kubernetes client to get the kube-system namespace UID
+	kubeClient, err := kubernetes.NewForConfig(providerConfig)
+	if err != nil {
+		conditions.MarkFalse(
+			bundle,
+			APIServiceBindingBundleConditionSynced,
+			"ProviderClientError",
+			conditionsapi.ConditionSeverityError,
+			"Failed to create provider core client: %v",
+			err,
+		)
+		return err
+	}
+
+	var providerID string
+	if kubeSystemNs, err := kubeClient.CoreV1().Namespaces().Get(ctx, "kube-system", metav1.GetOptions{}); err == nil {
+		providerID = string(kubeSystemNs.UID)
+	} else {
+		logger.Error(err, "Failed to get kube-system namespace from provider, ProviderID will be empty")
+	}
+
 	// List all APIServiceExports from the provider cluster
 	exports, err := providerClient.KubeBindV1alpha2().APIServiceExports(providerNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -261,6 +283,8 @@ func (r *reconciler) syncAPIServiceBindings(ctx context.Context, bundle *kubebin
 			},
 			Spec: kubebindv1alpha2.APIServiceBindingSpec{
 				KubeconfigSecretRef: bundle.Spec.KubeconfigSecretRef,
+				ProviderID:          providerID,
+				IsDefault:           true,
 			},
 		}
 

--- a/sdk/apis/kubebind/v1alpha2/apiservicebinding_types.go
+++ b/sdk/apis/kubebind/v1alpha2/apiservicebinding_types.go
@@ -88,6 +88,19 @@ type APIServiceBindingSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="kubeconfigSecretRef is immutable"
 	KubeconfigSecretRef ClusterSecretKeyRef `json:"kubeconfigSecretRef"`
+
+	// providerID is a stable and unique identifier for the provider cluster.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	ProviderID string `json:"providerID,omitempty"`
+
+	// isDefault indicates whether this binding should be used as the default routing
+	// destination for Custom Resources that do not specify a provider annotation.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	IsDefault bool `json:"isDefault,omitempty"`
 }
 
 type APIServiceBindingStatus struct {

--- a/sdk/apis/kubebind/v1alpha2/bindingresponse_types.go
+++ b/sdk/apis/kubebind/v1alpha2/bindingresponse_types.go
@@ -64,6 +64,12 @@ type BindingResourceResponse struct {
 	// +kubebuilder:validation:Optional
 	ProviderNamespace string `json:"providerNamespace,omitempty"`
 
+	// providerID is a stable and unique identifier for the provider cluster.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	ProviderID string `json:"providerID,omitempty"`
+
 	// bindingName is the confirmed name for this binding, as created on the service
 	// provider cluster.
 	//


### PR DESCRIPTION
## Description:
This pull request addresses Issue #173 by adding support for multi-provider bindings in `kube-bind`. It enables a single consumer cluster to bind and manage Custom Resources from multiple provider clusters without conflict.

## Changes made:

### API Extensions:
- Introduced ProviderID string in BindingResourceResponse (`sdk/apis/kubebind/v1alpha2/bindingresponse_types.go`).
- Introduced `ProviderID (string)` and I`sDefault` (bool) in `APIServiceBindingSpec` (`sdk/apis/kubebind/v1alpha2/apiservicebinding_types.go`).
- Updated CRD definitions via code generation.
### Backend:
- Updated HandleResources in `manager.go` to retrieve the provider cluster's kube-system namespace UID and set it as ProviderID.
- Included ProviderID in the `BindingResourceResponse` payload handled by the HTTP server (handler.go).
- Populated ProviderID in the `BindingResourceResponse` secret generated by the UI binding flow in `bindableresourcesrequest_controller.go`.
### CLI Binding Flow:
- Modified bind-apiservice plugin's createAPIServiceBindings function to map ProviderID and IsDefault into APIServiceBindingSpec.
### Konnector Core Engine:
- Updated `servicebindingbundle_reconcile.go` to inject the target `kube-system` UID into the generated `APIServiceBinding` spec upon reconciling provider connections.
- Extended spec and status controllers (`spec_controller.go` and `status_controller.go`) in `pkg/konnector/controllers/cluster/serviceexport/` to filter inbound syncing events. Controllers now only route resources that contain the `provider.kube-bind.io/provider-id` annotation matching their assigned ProviderID, or any resource if they hold the IsDefault flag.

## Testing and Validation
- Verified via local build (`make build`) that all integration logic compiles cleanly across both CLI and Backend components.
```bash
alokkumardalei@Aloks-MacBook-Air kbind % make build
hack/verify-go-versions.sh
Verifying minimum Go version: 1.26.2
Verifying build Go version: 1.26.2
+ cd ./cmd/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=da43199 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-da43199 -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:28:45Z -X k8s.io/component-base/version.gitCommit=da43199 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-da43199 -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:28:45Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
+ cd ./cli/cmd/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=da43199 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-da43199 -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:28:45Z -X k8s.io/component-base/version.gitCommit=da43199 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-da43199 -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:28:45Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
go: downloading k8s.io/cli-runtime v0.36.0
go: downloading k8s.io/component-base v0.36.0
go: downloading github.com/fatih/color v1.19.0
go: downloading k8s.io/client-go v0.36.0
go: downloading github.com/MakeNowJust/heredoc v1.0.0
go: downloading github.com/muesli/reflow v0.3.0
go: downloading github.com/moby/moby/client v0.4.1
go: downloading helm.sh/helm/v3 v3.20.2
go: downloading k8s.io/apimachinery v0.36.0
go: downloading sigs.k8s.io/kind v0.31.0
go: downloading k8s.io/api v0.36.0
go: downloading github.com/mattn/go-colorable v0.1.14
go: downloading github.com/mattn/go-isatty v0.0.21
go: downloading github.com/containerd/errdefs/pkg v0.3.0
go: downloading github.com/containerd/errdefs v1.0.0
go: downloading github.com/distribution/reference v0.6.0
go: downloading github.com/docker/go-connections v0.7.0
go: downloading github.com/moby/moby/api v1.54.2
go: downloading github.com/opencontainers/image-spec v1.1.1
go: downloading github.com/opencontainers/go-digest v1.0.0
go: downloading github.com/Masterminds/semver/v3 v3.4.0
go: downloading github.com/Masterminds/sprig/v3 v3.3.0
go: downloading github.com/gosuri/uitable v0.0.4
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/containerd/containerd v1.7.33
go: downloading oras.land/oras-go/v2 v2.6.0
go: downloading github.com/evanphx/json-patch v5.9.11+incompatible
go: downloading github.com/mattn/go-runewidth v0.0.23
go: downloading github.com/docker/go-units v0.5.0
go: downloading github.com/moby/docker-image-spec v1.3.1
go: downloading github.com/cyphar/filepath-securejoin v0.6.1
go: downloading github.com/mitchellh/copystructure v1.2.0
go: downloading github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
go: downloading github.com/BurntSushi/toml v1.6.0
go: downloading github.com/gobwas/glob v0.2.3
go: downloading github.com/hashicorp/go-multierror v1.1.1
go: downloading k8s.io/kubectl v0.36.0
go: downloading github.com/Masterminds/squirrel v1.5.4
go: downloading github.com/jmoiron/sqlx v1.4.0
go: downloading github.com/lib/pq v1.12.3
go: downloading github.com/rubenv/sql-migrate v1.8.1
go: downloading dario.cat/mergo v1.0.2
go: downloading github.com/Masterminds/goutils v1.1.1
go: downloading github.com/huandu/xstrings v1.5.0
go: downloading github.com/shopspring/decimal v1.4.0
go: downloading github.com/spf13/cast v1.10.0
go: downloading al.essio.dev/pkg/shellescape v1.6.0
go: downloading github.com/pelletier/go-toml v1.9.5
go: downloading github.com/mitchellh/reflectwalk v1.0.2
go: downloading github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
go: downloading k8s.io/apiserver v0.36.0
go: downloading github.com/clipperhouse/uax29/v2 v2.7.0
go: downloading github.com/hashicorp/errwrap v1.1.0
go: downloading github.com/containerd/log v0.1.0
go: downloading github.com/containerd/platforms v0.2.1
go: downloading github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
go: downloading github.com/go-gorp/gorp/v3 v3.1.0
go: downloading github.com/sirupsen/logrus v1.9.4
go: downloading github.com/klauspost/compress v1.18.5
go: downloading github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f
go: downloading github.com/chai2010/gettext-go v1.0.3
go: downloading github.com/mitchellh/go-wordwrap v1.0.1
go: downloading github.com/russross/blackfriday/v2 v2.1.0
go: downloading github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0
+ cd ./contrib/kcp/cmd/kcp-init/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=da43199 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-da43199 -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:28:45Z -X k8s.io/component-base/version.gitCommit=da43199 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-da43199 -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:28:45Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
go: downloading github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20260401063412-ba4f7d493d5b
go: downloading github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20260401063412-ba4f7d493d5b
go: downloading github.com/kcp-dev/client-go v0.31.0
go: downloading github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20260401063412-ba4f7d493d5b
go: downloading github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20260401063412-ba4f7d493d5b
go: downloading github.com/kcp-dev/kcp v0.31.0
go: downloading github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20260401063412-ba4f7d493d5b
go: downloading github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20260401063412-ba4f7d493d5b
go: downloading golang.org/x/crypto v0.51.0
go: downloading golang.org/x/net v0.55.0
go: downloading golang.org/x/sys v0.45.0
go: downloading golang.org/x/term v0.43.0
go: downloading golang.org/x/text v0.37.0
```
- Ran `make test` locally to ensure no pre-existing component behaviors were negatively impacted. All changes cleanly integrate with existing dynamic resource syncing logic.
```bash
         github.com/kube-bind/kube-bind/backend          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/auth             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/client           coverage: 0.0% of statements
?       github.com/kube-bind/kube-bind/backend/controllers      [no test files]
        github.com/kube-bind/kube-bind/backend/controllers/bindableresourcesrequest             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/cluster              coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/clusterbinding               coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/serviceexport                coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/backend/controllers/serviceexportrbac    1.489s  coverage: 51.2% of statements
        github.com/kube-bind/kube-bind/backend/controllers/serviceexportrequest         coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/servicenamespace             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/deploy           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/http             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/kubernetes               coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/backend/kubernetes/resources     2.495s  coverage: 4.7% of statements
ok      github.com/kube-bind/kube-bind/backend/oidc     2.222s  coverage: 33.3% of statements
ok      github.com/kube-bind/kube-bind/backend/options  1.417s  coverage: 9.6% of statements
        github.com/kube-bind/kube-bind/backend/options/session/redis            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/apibindingtemplate              coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/apiresourceschema               coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/shared          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/vwrbac          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/options             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/session          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/session/memory           coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/backend/session/redis    1.384s  coverage: 81.1% of statements
        github.com/kube-bind/kube-bind/backend/spaserver                coverage: 0.0% of statements
?       github.com/kube-bind/kube-bind/backend/template [no test files]
        github.com/kube-bind/kube-bind/cmd/backend              coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/cmd/konnector            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/cmd/konnector/cmd                coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/deploy/crd               coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/deploy/examples          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/bootstrap            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/committer            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/indexers             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster                coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/claimedresources       1.426s  coverage: 5.7% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/claimedresourcesnamespaces          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/clusterbinding         coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/namespacelifecycle             coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/servicebinding 1.586s  coverage: 21.2% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport  1.949s  coverage: 3.2% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/isolation        2.285scoverage: 5.6% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/multinsinformer       coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/spec     2.612s  coverage: 3.8% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/status           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/contextstore           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/dynamic                coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/servicebinding         coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/servicebindingbundle           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/options            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/server             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/types              coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/resources    2.572s  coverage: 57.4% of statements
ok      github.com/kube-bind/kube-bind/pkg/version      2.857s  coverage: 88.9% of statements
```
Fixes #173
