### PR TITLE
refactor: cleanup apiservice.Binder duplication (#360)

### DIFF
--- a/cli/pkg/kubectl/bind-apiservice/plugin/binder.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/binder.go
@@ -65,10 +65,6 @@ func NewBinder(config *rest.Config, opts *BinderOptions) *Binder {
 	}
 }
 
-// TODO: bindFromFile and bindFromResponse can likely share a lot of code. This slow is bit repetitive
-// but keeps the two paths separate for clarity. But it needs love.
-// https://github.com/kube-bind/kube-bind/issues/360
-
 func (b *Binder) BindFromFile(ctx context.Context) ([]*kubebindv1alpha2.APIServiceBinding, error) {
 	// Generate the kubectl command that would be equivalent
 	remoteFlags := ""
@@ -81,52 +77,17 @@ func (b *Binder) BindFromFile(ctx context.Context) ([]*kubebindv1alpha2.APIServi
 	fmt.Fprintf(b.opts.IOStreams.ErrOut, "✨ Use \"-o yaml\" and \"--dry-run\" to get the APIServiceExportRequest.\n")
 	fmt.Fprintf(b.opts.IOStreams.ErrOut, "    and pass it to \"kubectl bind apiservice\" directly. Great for automation.\n")
 
-	// Ensure client side namespace exists
-	err := b.ensureClientSideNamespaceExists(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure kube-bind namespace exists: %w", err)
-	}
-
 	remoteKubeconfig, _, _, err := b.getRemoteKubeconfig(ctx, "", "")
 	if err != nil {
 		return nil, err
 	}
 
-	// Copy kubeconfig into local cluster
-	remoteHost, remoteNamespace, err := base.ParseRemoteKubeconfig([]byte(remoteKubeconfig))
+	remoteKubeconfigResolved, remoteNamespaceActual, remoteConfig, err := b.setupEnvironment(ctx, []byte(remoteKubeconfig))
 	if err != nil {
 		return nil, err
 	}
-
-	kubeClient, err := kubeclient.NewForConfig(b.config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	secretName, err := base.FindRemoteKubeconfig(ctx, kubeClient, remoteNamespace, remoteHost)
-	if err != nil {
-		return nil, err
-	}
-
-	secret, created, err := base.EnsureKubeconfigSecret(ctx, remoteKubeconfig, secretName, kubeClient)
-	if err != nil {
-		return nil, err
-	}
-
-	if created {
-		fmt.Fprintf(b.opts.IOStreams.ErrOut, "🔒 Created secret %s/%s for host %s, namespace %s\n", "kube-bind", secret.Name, remoteHost, remoteNamespace)
-	} else {
-		fmt.Fprintf(b.opts.IOStreams.ErrOut, "🔒 Updated secret %s/%s for host %s, namespace %s\n", "kube-bind", secret.Name, remoteHost, remoteNamespace)
-	}
-
 	if b.opts.DryRun {
 		return nil, nil
-	}
-
-	// Get remote kubeconfig
-	remoteKubeconfig, remoteNamespaceActual, remoteConfig, err := b.getRemoteKubeconfig(ctx, secret.Namespace, secret.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get remote kubeconfig: %w", err)
 	}
 
 	data, err := b.getRequestManifest()
@@ -139,77 +100,20 @@ func (b *Binder) BindFromFile(ctx context.Context) ([]*kubebindv1alpha2.APIServi
 		return nil, fmt.Errorf("failed to unmarshal request manifest: %w", err)
 	}
 
-	// Deploy konnector if needed
-	if err := b.deployKonnector(ctx); err != nil {
-		return nil, fmt.Errorf("failed to deploy konnector: %w", err)
-	}
-
-	// Create bindings for all requests
-	result, err := b.createServiceExportRequest(ctx, remoteConfig, remoteNamespaceActual, request)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create service export request: %w", err)
-	}
-
-	secretName, err = b.createKubeconfigSecret(ctx, remoteConfig.Host, remoteNamespaceActual, remoteKubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubeconfig secret: %w", err)
-	}
-
-	results, err := b.createAPIServiceBindings(ctx, result, secretName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create API service bindings: %w", err)
-	}
-
-	return results, nil
+	return b.processRequests(ctx, []*kubebindv1alpha2.APIServiceExportRequest{request}, remoteConfig, remoteNamespaceActual, remoteKubeconfigResolved)
 }
-
 // BindFromResponse processes a BindingResourceResponse and creates all necessary bindings
 func (b *Binder) BindFromResponse(ctx context.Context, response *kubebindv1alpha2.BindingResourceResponse) ([]*kubebindv1alpha2.APIServiceBinding, error) {
 	if response == nil || response.Authentication.OAuth2CodeGrant == nil {
 		return nil, fmt.Errorf("unexpected response: authentication.oauth2CodeGrant is nil")
 	}
 
-	// Ensure client side namespace exists
-	err := b.ensureClientSideNamespaceExists(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure kube-bind namespace exists: %w", err)
-	}
-
-	// Copy kubeconfig into local cluster
-	remoteHost, remoteNamespace, err := base.ParseRemoteKubeconfig(response.Kubeconfig)
+	remoteKubeconfigResolved, remoteNamespaceActual, remoteConfig, err := b.setupEnvironment(ctx, response.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
-
-	kubeClient, err := kubeclient.NewForConfig(b.config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	secretName, err := base.FindRemoteKubeconfig(ctx, kubeClient, remoteNamespace, remoteHost)
-	if err != nil {
-		return nil, err
-	}
-
-	secret, created, err := base.EnsureKubeconfigSecret(ctx, string(response.Kubeconfig), secretName, kubeClient)
-	if err != nil {
-		return nil, err
-	}
-
-	if created {
-		fmt.Fprintf(b.opts.IOStreams.ErrOut, "🔒 Created secret %s/%s for host %s, namespace %s\n", "kube-bind", secret.Name, remoteHost, remoteNamespace)
-	} else {
-		fmt.Fprintf(b.opts.IOStreams.ErrOut, "🔒 Updated secret %s/%s for host %s, namespace %s\n", "kube-bind", secret.Name, remoteHost, remoteNamespace)
-	}
-
 	if b.opts.DryRun {
 		return nil, nil
-	}
-
-	// Get remote kubeconfig
-	remoteKubeconfig, remoteNamespaceActual, remoteConfig, err := b.getRemoteKubeconfig(ctx, secret.Namespace, secret.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get remote kubeconfig: %w", err)
 	}
 
 	// Extract the requests
@@ -229,6 +133,57 @@ func (b *Binder) BindFromResponse(ctx context.Context, response *kubebindv1alpha
 		apiRequests[i] = &apiRequest
 	}
 
+	return b.processRequests(ctx, apiRequests, remoteConfig, remoteNamespaceActual, remoteKubeconfigResolved)
+}
+
+func (b *Binder) setupEnvironment(ctx context.Context, remoteKubeconfigBytes []byte) (string, string, *rest.Config, error) {
+	// Ensure client side namespace exists
+	err := b.ensureClientSideNamespaceExists(ctx)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to ensure kube-bind namespace exists: %w", err)
+	}
+
+	// Copy kubeconfig into local cluster
+	remoteHost, remoteNamespace, err := base.ParseRemoteKubeconfig(remoteKubeconfigBytes)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	kubeClient, err := kubeclient.NewForConfig(b.config)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	secretName, err := base.FindRemoteKubeconfig(ctx, kubeClient, remoteNamespace, remoteHost)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	secret, created, err := base.EnsureKubeconfigSecret(ctx, string(remoteKubeconfigBytes), secretName, kubeClient)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	if created {
+		fmt.Fprintf(b.opts.IOStreams.ErrOut, "🔒 Created secret %s/%s for host %s, namespace %s\n", "kube-bind", secret.Name, remoteHost, remoteNamespace)
+	} else {
+		fmt.Fprintf(b.opts.IOStreams.ErrOut, "🔒 Updated secret %s/%s for host %s, namespace %s\n", "kube-bind", secret.Name, remoteHost, remoteNamespace)
+	}
+
+	if b.opts.DryRun {
+		return "", "", nil, nil
+	}
+
+	// Get remote kubeconfig
+	remoteKubeconfig, remoteNamespaceActual, remoteConfig, err := b.getRemoteKubeconfig(ctx, secret.Namespace, secret.Name)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("failed to get remote kubeconfig: %w", err)
+	}
+
+	return remoteKubeconfig, remoteNamespaceActual, remoteConfig, nil
+}
+
+func (b *Binder) processRequests(ctx context.Context, apiRequests []*kubebindv1alpha2.APIServiceExportRequest, remoteConfig *rest.Config, remoteNamespaceActual string, remoteKubeconfig string) ([]*kubebindv1alpha2.APIServiceBinding, error) {
 	// Deploy konnector if needed
 	if err := b.deployKonnector(ctx); err != nil {
 		return nil, fmt.Errorf("failed to deploy konnector: %w", err)

--- a/cli/pkg/kubectl/bind-apiservice/plugin/binder.go
+++ b/cli/pkg/kubectl/bind-apiservice/plugin/binder.go
@@ -102,6 +102,7 @@ func (b *Binder) BindFromFile(ctx context.Context) ([]*kubebindv1alpha2.APIServi
 
 	return b.processRequests(ctx, []*kubebindv1alpha2.APIServiceExportRequest{request}, remoteConfig, remoteNamespaceActual, remoteKubeconfigResolved)
 }
+
 // BindFromResponse processes a BindingResourceResponse and creates all necessary bindings
 func (b *Binder) BindFromResponse(ctx context.Context, response *kubebindv1alpha2.BindingResourceResponse) ([]*kubebindv1alpha2.APIServiceBinding, error) {
 	if response == nil || response.Authentication.OAuth2CodeGrant == nil {


### PR DESCRIPTION
(Fixes #360)
This pull request addresses Issue #360 by refactoring and cleaning up the Binder logic in `cli/pkg/kubectl/bind-apiservice/plugin/binder.go`.

## Changes made

### Extracted Helper Methods:
- Created setupEnvironment(`ctx context.Context`, `remoteKubeconfigBytes []byte`) (`string, string`, `*rest.Config`, `error`) to encapsulate common environment initialization logic (ensuring the client-side namespace exists, parsing/saving the remote `kubeconfig`, and fetching the resolved config).
- Created processRequests(`ctx context.Context`, `apiRequests []*kubebindv1alpha2.APIServiceExportRequest`, remoteConfig `*rest.Config`, `remoteNamespaceActual string`, `remoteKubeconfig` string) (`[]*kubebindv1alpha2.APIServiceBinding`, error) to handle the common request processing loop (deploying konnector, creating service export requests, saving secrets, and creating bindings).
### Refactored Entrypoints:
- BindFromFile: Updated to use setupEnvironment and processRequests, eliminating large blocks of duplicated boilerplate.
- BindFromResponse: Updated similarly to utilize the new helpers for processing the multiple requests present in the response.

## Testing and Validation
- Verified via local build (`make build`) that the refactored logic compiles cleanly.
```bash
hack/verify-go-versions.sh
Verifying minimum Go version: 1.26.2
Verifying build Go version: 1.26.2
+ cd ./cmd/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=92a6cb2 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-92a6cb2 -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:38:57Z -X k8s.io/component-base/version.gitCommit=92a6cb2 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-92a6cb2 -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:38:57Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
+ cd ./cli/cmd/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=92a6cb2 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-92a6cb2 -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:38:57Z -X k8s.io/component-base/version.gitCommit=92a6cb2 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-92a6cb2 -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:38:57Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
+ cd ./contrib/kcp/cmd/kcp-init/
+ go build '-ldflags=-X k8s.io/client-go/pkg/version.gitCommit=92a6cb2 -X k8s.io/client-go/pkg/version.gitTreeState=clean -X k8s.io/client-go/pkg/version.gitVersion=v1.36.0+kube-bind-v0.0.0-92a6cb2 -X k8s.io/client-go/pkg/version.gitMajor=1 -X k8s.io/client-go/pkg/version.gitMinor=36 -X k8s.io/client-go/pkg/version.buildDate=2026-07-17T15:38:57Z -X k8s.io/component-base/version.gitCommit=92a6cb2 -X k8s.io/component-base/version.gitTreeState=clean -X k8s.io/component-base/version.gitVersion=v1.36.0+kube-bind-v0.0.0-92a6cb2 -X k8s.io/component-base/version.gitMajor=1 -X k8s.io/component-base/version.gitMinor=36 -X k8s.io/component-base/version.buildDate=2026-07-17T15:38:57Z' -o /Users/alokkumardalei/Desktop/kbind/kbind/bin/ ./...
```
- Ran make test locally to ensure the plugin's behavior remains unchanged.
```bash
github.com/kube-bind/kube-bind/backend          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/auth             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/client           coverage: 0.0% of statements
?       github.com/kube-bind/kube-bind/backend/controllers      [no test files]
        github.com/kube-bind/kube-bind/backend/controllers/bindableresourcesrequest             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/cluster              coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/clusterbinding               coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/serviceexport                coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/backend/controllers/serviceexportrbac    1.695s  coverage: 51.2% of statements
        github.com/kube-bind/kube-bind/backend/controllers/serviceexportrequest         coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/controllers/servicenamespace             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/deploy           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/http             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/kubernetes               coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/backend/kubernetes/resources     2.367s  coverage: 4.7% of statements
ok      github.com/kube-bind/kube-bind/backend/oidc     1.659s  coverage: 33.3% of statements
ok      github.com/kube-bind/kube-bind/backend/options  1.416s  coverage: 9.6% of statements
        github.com/kube-bind/kube-bind/backend/options/session/redis            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/apibindingtemplate              coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/apiresourceschema               coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/shared          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/controllers/vwrbac          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/provider/kcp/options             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/session          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/backend/session/memory           coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/backend/session/redis    1.660s  coverage: 81.1% of statements
        github.com/kube-bind/kube-bind/backend/spaserver                coverage: 0.0% of statements
?       github.com/kube-bind/kube-bind/backend/template [no test files]
        github.com/kube-bind/kube-bind/cmd/backend              coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/cmd/konnector            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/cmd/konnector/cmd                coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/deploy/crd               coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/deploy/examples          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/bootstrap            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/committer            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/indexers             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster                coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/claimedresources       1.544s  coverage: 5.7% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/claimedresourcesnamespaces          coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/clusterbinding         coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/namespacelifecycle             coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/servicebinding 1.634s  coverage: 21.2% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport  1.966s  coverage: 3.2% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/isolation        2.071scoverage: 5.6% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/multinsinformer       coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/spec     2.209s  coverage: 4.1% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/cluster/serviceexport/status           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/contextstore           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/dynamic                coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/servicebinding         coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/controllers/servicebindingbundle           coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/options            coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/server             coverage: 0.0% of statements
        github.com/kube-bind/kube-bind/pkg/konnector/types              coverage: 0.0% of statements
ok      github.com/kube-bind/kube-bind/pkg/resources    1.665s  coverage: 57.4% of statements
ok      github.com/kube-bind/kube-bind/pkg/version      1.713s  coverage: 88.9% of statements
```