### PR TITLE
Annotate Leases with Connection name

### DIFF
--- a/engine/connection/reconciler.go
+++ b/engine/connection/reconciler.go
@@ -268,6 +268,7 @@ func (r *Reconciler) heartbeat(ctx context.Context, providerClient client.Client
 			lease.Annotations = map[string]string{}
 		}
 		lease.Annotations[corev1alpha1.AnnotationConsumerClusterUID] = conn.Status.LocalClusterUID
+		lease.Annotations[corev1alpha1.AnnotationConnection] = conn.Name
 		lease.Spec.HolderIdentity = ptr.To(conn.Status.LocalClusterUID)
 		lease.Spec.LeaseDurationSeconds = ptr.To(int32(leaseDurationSeconds))
 		if lease.Spec.AcquireTime == nil {

--- a/sdk/apis/core/v1alpha1/labels.go
+++ b/sdk/apis/core/v1alpha1/labels.go
@@ -27,9 +27,10 @@ const (
 	// the provider.
 	LabelManaged = "core.kbind.io/managed"
 
-	// AnnotationConnection records, on a pulled consumer CRD, the name of the
-	// Connection whose provider it was pulled from. The sync engine uses it to
-	// pin the provider cluster for that API.
+	// AnnotationConnection records the name of the Connection.
+	// Used on pulled consumer CRD so that the sync engine can pin
+	// the provider cluster for that API. It's also used on Leases to maintain
+	// the link between consumer's Connection and provider's Lease.
 	AnnotationConnection = "core.kbind.io/connection"
 
 	// AnnotationConsumerClusterUID records the consumer cluster identity on a


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

Annotate Leases with Connection name. This is needed so that on the provider's side we can make the link between a lease and the bundle.

## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

/kind feature

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
